### PR TITLE
Add subscribeC method to Circuit, which passes unsubscribe callback to the listener

### DIFF
--- a/diode-core/shared/src/test/scala/diode/CircuitTests.scala
+++ b/diode-core/shared/src/test/scala/diode/CircuitTests.scala
@@ -279,6 +279,24 @@ object CircuitTests extends TestSuite {
         assert(state2.s == state2Snapshot.s)
         assert(callback2Count == callback2CountSnapshot)
       }
+      'WithCallbackReference - {
+        val c = circuit
+        var state: Model = null
+        var callbackCount = 0
+        def listener(cursor: ModelR[Model, String]): (() ⇒ Unit) ⇒ Unit = unsubscribe ⇒ {
+          state = c.model
+          callbackCount += 1
+          unsubscribe()
+        }
+        c.subscribeC(c.zoom(_.s))(listener)
+        c.dispatch(SetS("Listen"))
+        assert(state.s == "Listen")
+        assert(callbackCount == 1)
+        c.dispatch(SetS("Listen1"))
+        // unsubscribe should already be called, so no changes
+        assert(state.s == "Listen")
+        assert(callbackCount == 1)
+      }
     }
     'Effects - {
       'Run - {


### PR DESCRIPTION
There are cases when unsubscription is done by the listener, depending on state received from the cursor. For this to work, you have to create a variable for unsubscribe callback, to be able to reference it in the listener:

``` scala
var unsubscribe: () ⇒ Unit = () ⇒ ()
unsubscribe = SomeCircuit.subscribe(...)(v ⇒ {
  //...
  unsubscribe()
  //...
})
```

This PR defines a more general `subscribeC`, that passes unsubscribe callback to the listener (and implements current `subscribe` in terms of `subscribeC`.
I don't like the name, but I couldn't come up with anything better, so I'm open to ideas here :)
