### PR TITLE
Hint about implicit ExecutionContext in docs

### DIFF
--- a/doc/usage/Effects.md
+++ b/doc/usage/Effects.md
@@ -25,6 +25,7 @@ To create an effect you need a function that runs something asynchronously, for 
  
 ```scala
 import org.scalajs.dom.ext.Ajax
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 case class NewMessages(msgs: String) extends Action
 


### PR DESCRIPTION
As `Effect` requires implicit ExecutionContext for it's creation, it seems to be worth adding some hint about how to specify it. It took me a while to find the solution for `Cannot find an implicit ExecutionContext. ...` error.

```
import scala.concurrent.ExecutionContext.Implicits.global
```
is another candidate, but I'm not sure will the whole thing work in concurrent environment, and maybe it is a good idea to restrict it's usage to explicitly single-threaded `scala.scalajs.concurrent.JSExecutionContext.Implicits.queue`. Please correct me if I'm missing something fundamental, and Diode indeed works concurrently.