### PR TITLE
Improve readability and efficiency of toTagMod in TodoMVC example

### DIFF
--- a/examples/todomvc/src/main/scala/example/Footer.scala
+++ b/examples/todomvc/src/main/scala/example/Footer.scala
@@ -36,7 +36,7 @@ object Footer {
         ),
         <.ul(
           ^.className := "filters",
-          TodoFilter.values.map(filterLink(p)(_)).toTagMod
+          TodoFilter.values.toTagMod(filterLink(p)(_))
         ),
         clearButton(p)
       )

--- a/examples/todomvc/src/main/scala/example/TodoList.scala
+++ b/examples/todomvc/src/main/scala/example/TodoList.scala
@@ -67,7 +67,7 @@ object TodoList {
         ),
         <.ul(
           ^.className := "todo-list",
-          todos.map(
+          todos.toTagMod(
             todo =>
               TodoView(TodoView.Props(
                 onToggle = dispatch(ToggleCompleted(todo.id)),
@@ -77,7 +77,7 @@ object TodoList {
                 onCancelEditing = editingDone(),
                 todo = todo,
                 isEditing = editing.contains(todo.id)
-              ))).toTagMod
+              )))
         )
       )
 


### PR DESCRIPTION
Examples should be an example! :)

@japgolly suggested in https://github.com/japgolly/scalajs-react/blob/master/doc/VDOM.md:
"If you find yourself with .map(...).toTagMod, replace it with just .toTagMod(...) for improved readability and efficiency"

I changed the example according to the advice.