### PR TITLE
Fix Redux introduction link URL

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ tenets:
 3. State is always replaced with the next state
 
 If you are interested in the motivation, or prior art for Diode, we recommend reading through 
-[Redux introduction](http://rackt.org/redux/docs/introduction/index.html) and [Flux architecture](https://facebook.github.io/flux/docs/overview.html#content).
+[Redux introduction](http://redux.js.org/docs/introduction/) and [Flux architecture](https://facebook.github.io/flux/docs/overview.html#content).
 Both give a great overview on the benefits of unidirectional data flow and immutable state.
 
 To use Diode in your application add following dependency declaration to your Scala project.


### PR DESCRIPTION
Current Redux introduction link lands to strange rack.org web site. 
http://redux.js.org seems to be the current right place to Redux project.