### PR TITLE
Upgrade ScalaJS-React and ScalaJS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val diodeReact = project
   .settings(
     name := "diode-react",
     libraryDependencies ++= Seq(
-      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC2"
+      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC3"
     ),
     scalacOptions ++= sourceMapSetting.value
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 


### PR DESCRIPTION
Upgrading ScalaJS-React dependency to 1.0.0-RC3 and ScalaJS to 0.6.15. This fixes linkage errors during the fast opt JS phase.