### PR TITLE
Use the existing startTime in Pending and PendingStale PotState

### DIFF
--- a/diode-data/shared/src/main/scala/diode/data/Pot.scala
+++ b/diode-data/shared/src/main/scala/diode/data/Pot.scala
@@ -402,7 +402,7 @@ final case class Pending(startTime: Long = Pot.currentTime) extends Pot[Nothing]
   def isFailed = false
   def isStale  = false
 
-  override def pending(startTime: Long = Pot.currentTime) = copy(startTime)
+  override def pending(startTime: Long = startTime) = copy(startTime)
   override def fail(exception: Throwable)                 = Failed(exception)
 }
 
@@ -412,7 +412,7 @@ final case class PendingStale[+A](x: A, startTime: Long = Pot.currentTime) exten
   def isFailed = false
   def isStale  = true
 
-  override def pending(startTime: Long = Pot.currentTime) = copy(x, startTime)
+  override def pending(startTime: Long = startTime) = copy(x, startTime)
   override def fail(exception: Throwable)                 = FailedStale(x, exception)
 }
 

--- a/diode-data/shared/src/test/scala/diode/data/PotTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotTests.scala
@@ -38,12 +38,14 @@ object PotTests extends TestSuite {
         val pend       = empty.pending(startTime0)
         assert(pend.asInstanceOf[PendingBase].startTime == startTime0)
         assert(pend.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0)
-        assert(pend.pending().asInstanceOf[PendingBase].startTime > startTime0)
+        assert(pend.pending().asInstanceOf[PendingBase].startTime == startTime0)
         val ready = pend.ready("a")
         assert(ready.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0)
+        assert(ready.pending(startTime0).pending().asInstanceOf[PendingBase].startTime == startTime0)
         assert(ready.pending().asInstanceOf[PendingBase].startTime != startTime0)
         val fail = ready.fail(new Exception)
         assert(fail.pending(startTime0).asInstanceOf[PendingBase].startTime == startTime0)
+        assert(fail.pending(startTime0).pending().asInstanceOf[PendingBase].startTime == startTime0)
         assert(fail.pending().asInstanceOf[PendingBase].startTime > startTime0)
       }
     }


### PR DESCRIPTION
As discussed in https://github.com/suzaku-io/diode/issues/65