### PR TITLE
Align ReactPot with scalajs-react 1.2.0

### DIFF
--- a/diode-react/src/main/scala/diode/react/ReactPot.scala
+++ b/diode-react/src/main/scala/diode/react/ReactPot.scala
@@ -1,7 +1,8 @@
 package diode.react
 
 import diode.data.{PendingBase, Pot}
-import japgolly.scalajs.react.vdom.{VdomArray, VdomNode}
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.vdom.Exports.EmptyVdom
 
 object ReactPot {
 
@@ -14,7 +15,7 @@ object ReactPot {
       * @return
       */
     def render(f: A => VdomNode): VdomNode =
-      if (pot.nonEmpty) f(pot.get) else VdomArray.empty()
+      if (pot.nonEmpty) f(pot.get) else EmptyVdom
 
     /**
       * Render content in Ready state, not including stale states
@@ -23,7 +24,7 @@ object ReactPot {
       * @return
       */
     def renderReady(f: A => VdomNode): VdomNode =
-      if (pot.isReady) f(pot.get) else VdomArray.empty()
+      if (pot.isReady) f(pot.get) else EmptyVdom
 
     /**
       * Render when Pot is pending
@@ -32,7 +33,7 @@ object ReactPot {
       * @return
       */
     def renderPending(f: Int => VdomNode): VdomNode =
-      if (pot.isPending) f(pot.asInstanceOf[PendingBase].duration()) else VdomArray.empty()
+      if (pot.isPending) f(pot.asInstanceOf[PendingBase].duration()) else EmptyVdom
 
     /**
       * Render when Pot is pending with a filter on duration
@@ -44,8 +45,8 @@ object ReactPot {
     def renderPending(b: Int => Boolean, f: Int => VdomNode): VdomNode = {
       if (pot.isPending) {
         val duration = pot.asInstanceOf[PendingBase].duration()
-        if (b(duration)) f(duration) else VdomArray.empty()
-      } else VdomArray.empty()
+        if (b(duration)) f(duration) else EmptyVdom
+      } else EmptyVdom
     }
 
     /**
@@ -55,7 +56,7 @@ object ReactPot {
       * @return
       */
     def renderFailed(f: Throwable => VdomNode): VdomNode =
-      pot.exceptionOption.map(f).getOrElse(VdomArray.empty())
+      pot.exceptionOption.map(f).getOrElse(EmptyVdom)
 
     /**
       * Render stale content (`PendingStale` or `FailedStale`)
@@ -64,7 +65,7 @@ object ReactPot {
       * @return
       */
     def renderStale(f: A => VdomNode): VdomNode =
-      if (pot.isStale) f(pot.get) else VdomArray.empty()
+      if (pot.isStale) f(pot.get) else EmptyVdom
 
     /**
       * Render when Pot is empty
@@ -73,7 +74,7 @@ object ReactPot {
       * @return
       */
     def renderEmpty(f: => VdomNode): VdomNode =
-      if (pot.isEmpty) f else VdomArray.empty()
+      if (pot.isEmpty) f else EmptyVdom
   }
 
 }


### PR DESCRIPTION
With the introduction of scalajs-react 1.2.0 we were introduced to `EmptyVdom` becoming a `VdomNode` instead of a `TagMod`. This changes `ReactPot` to use `EmptyVdom` instead of `VdomArray.empty()`
