### PR TITLE
Allow to subscribe to ZipModel fix #58

### DIFF
--- a/diode-core/shared/src/main/scala/diode/ModelRW.scala
+++ b/diode-core/shared/src/main/scala/diode/ModelRW.scala
@@ -275,7 +275,10 @@ class ZipModelR[M, S, SS](val root: ModelR[M, M], get1: M => S, get2: M => SS)(i
     zipped
   }
 
-  override def ===(that: (S, SS)) = zipped eq that
+  override def ===(that: (S, SS)) = {
+    // using fast eq is required to support zip in subscribe
+    feqS.eqv(get1(root.value), that._1) && feqSS.eqv(get2(root.value), that._2)
+  }
 }
 
 /**

--- a/diode-core/shared/src/test/scala/diode/ModelRWTests.scala
+++ b/diode-core/shared/src/test/scala/diode/ModelRWTests.scala
@@ -75,6 +75,8 @@ object ModelRWTests extends TestSuite {
       val v2 = z2.value
       assert(z2.value == ((m.a.i, m.b.max)))
 
+      assert(z1 ===((r1.value, r4.value)))
+
       m = m.copy(m.a.copy(s = "diode"))
       assert(v1 ne z1.value)
       // a.i and b have not changed
@@ -88,6 +90,21 @@ object ModelRWTests extends TestSuite {
       m = m.copy(b = m.b.copy(max = 44))
       // a.i and b.max have both changed
       assert(v2 ne z2.value)
+
+      // Previous behaviour before supporting subscribe for zip
+
+      // should not be === when providing a different value
+      assert(!(z1 ===((r1.value.copy(i = 0), r4.value))))
+      assert(!(z1 ===((r1.value, Seq(-1, -2)))))
+
+      // should not be === when providing a copy with changed reference
+      assert(!(z1 ===((m.a.copy(i = m.a.i), r4.value))))
+      assert(!(z1 ===((r1.value, m.b.fs.toArray.toSeq))))
+
+      // new behaviour after supporting subscribe for zip
+      // should be === when unchanged
+      assert(z1 ===((r1.value, r4.value)))
+
     }
     'map - {
       'equality - {


### PR DESCRIPTION
Hi,

I asked a few days ago on Gitter about zip support for subscribe and I saw 2 hours ago that an issue was open on it.
So this is the PR I suggest for it.

It updates ZipModelR === to use fast eq as suggested in the issue.

Regards,
