### PR TITLE
[diode] Updating library and project deps to latest versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,17 @@
 import sbt._
 import Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
+// shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-crossScalaVersions := Seq("2.11.12", "2.12.6")
+crossScalaVersions := Seq("2.11.12", "2.12.8")
 
 ThisBuild / scalafmtOnCompile := true
 
 val commonSettings = Seq(
   organization := "io.suzaku",
   version := Version.library,
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.8",
   scalacOptions := Seq(
     "-deprecation",
     "-encoding",
@@ -33,7 +35,7 @@ val commonSettings = Seq(
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.5.3" % "test"
+    "com.lihaoyi" %%% "utest" % "0.6.6" % "test"
   )
 )
 
@@ -93,7 +95,8 @@ def preventPublication(p: Project) =
     packagedArtifacts := Map.empty
   )
 
-lazy val diodeCore = crossProject
+lazy val diodeCore = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
   .in(file("diode-core"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
@@ -110,7 +113,8 @@ lazy val diodeCoreJS = diodeCore.js
 
 lazy val diodeCoreJVM = diodeCore.jvm
 
-lazy val diodeData = crossProject
+lazy val diodeData = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
   .in(file("diode-data"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
@@ -127,7 +131,9 @@ lazy val diodeDataJS = diodeData.js
 
 lazy val diodeDataJVM = diodeData.jvm
 
-lazy val diode = crossProject
+lazy val diode = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .in(file("diode"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(
@@ -139,7 +145,8 @@ lazy val diodeJS = diode.js
 
 lazy val diodeJVM = diode.jvm
 
-lazy val diodeDevtools = crossProject
+lazy val diodeDevtools = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
   .in(file("diode-devtools"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
@@ -148,7 +155,7 @@ lazy val diodeDevtools = crossProject
   )
   .jsSettings(
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.3"
+      "org.scala-js" %%% "scalajs-dom" % "0.9.6"
     ),
     scalacOptions ++= sourceMapSetting.value
   )

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
   val library = "1.1.4"
-  val sjsReact = "1.3.1"
+  val sjsReact = "1.4.0"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 


### PR DESCRIPTION
This PR updates the library dependencies of diode to the latest versions:

| Dependency | Old Version | New Version |
| :--- | :---: | :---: |
| scalajs-react | 1.3.1 | 1.4.0 |
| scalajs-dom | 0.9.3 | 0.9.6 |
| utest | 0.5.3 | 0.6.6 |

And project dependencies to the latest versions:

| Dependency | Old Version | New Version |
| :--- | :---: | :---: |
| sbt-scalajs | 0.6.22 | 0.6.26 |
| sbt-scalajs-crossproject | - | 0.6.0 |
| sbt | 1.1.5 | 1.2.8 |

It also increments the cross scala version for `2.12.x` from `2.12.6` to `2.12.8`.