### PR TITLE
Remove componentWillMount as it will become deprecated

### DIFF
--- a/diode-react/src/main/scala/diode/react/ReactConnector.scala
+++ b/diode-react/src/main/scala/diode/react/ReactConnector.scala
@@ -100,7 +100,7 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
     class Backend(t: BackendScope[ReactConnectProps[S], S]) {
       private var unsubscribe = Option.empty[() => Unit]
 
-      def willMount = {
+      def didMount = {
         // subscribe to model changes
         Callback {
           unsubscribe = Some(circuit.subscribe(modelReader.asInstanceOf[ModelR[M, S]])(changeHandler))
@@ -128,7 +128,7 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
       .builder[ReactConnectProps[S]]("DiodeWrapper")
       .initialState(modelReader())
       .renderBackend[Backend]
-      .componentWillMount(_.backend.willMount)
+      .componentDidMount(_.backend.didMount)
       .componentWillUnmount(_.backend.willUnmount)
       .shouldComponentUpdatePure(scope => (scope.currentState ne scope.nextState) || (scope.currentProps ne scope.nextProps))
       .build


### PR DESCRIPTION
ComponentWillMount will become deprecated in React 17, ComponentDidMount seems to be suggested replacement.