### PR TITLE
Update build to support Scala.js 1.0.0-RC2 as well as 0.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ node_js:
 - 8
 - oraclejdk8
 script:
-- sbt +test
+- SCALAJS_VERSION="0.6.31" sbt +test
+- SCALAJS_VERSION="1.0.0-RC2" sbt +test
 # Tricks to avoid unnecessary cache updates, from
 # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
 - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 1.1.7
+- Allow cross-building for any ScalaJS version - default is 1.0.0-RC2
+- The build uses the `SCALAJS_VERSION` environment variable to get the scala.js plugin version for the build
+- The diode-react sub-project is now only built for 0.6.x builds
+- Bump scala cross versions to 2.12.10 and 2.13.1
+- Adjust for change where higher kinds are directly supported in 2.13.1
+
+
 ## 1.1.6
 - Cross-Build for Scala 2.12.8 (all projects) and 2.13.0 (for 'core', 'devtools', and 'data' projects only)
 - Drops support for Scala 2.11.x because dependencies no longer support it.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Full documentation [available here](https://diode.suzaku.io).
 Add following dependency declaration to your Scala project.
 
 ```scala
-"io.suzaku" %% "diode" % "1.1.6"
+"io.suzaku" %% "diode" % "1.1.7"
 ```
 
 In a Scala.js project the dependency looks like this.
 
 ```scala
-"io.suzaku" %%% "diode" % "1.1.6"
+"io.suzaku" %%% "diode" % "1.1.7"
 ```
 
 Starting with version "1.1.6" diode has dropped support for Scala 2.11. If you need 2.11 support use version "1.1.5"

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ ThisBuild / scalafmtOnCompile := true
 val commonSettings = Seq(
   organization := "io.suzaku",
   version := Version.library,
-  crossScalaVersions := Seq("2.12.8"),
-  scalaVersion in ThisBuild := "2.12.8",
+  crossScalaVersions := Seq("2.12.10"),
+  scalaVersion in ThisBuild := "2.12.10",
   scalacOptions := Seq(
     "-deprecation",
     "-encoding",
@@ -25,14 +25,14 @@ val commonSettings = Seq(
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) => Seq("-Xlint:-unused")
+    case Some((2, 12)) => Seq("-Xlint:-unused", "-language:higherKinds")
     case _             => Nil
   }),
   Compile / scalacOptions -= "-Ywarn-value-discard",
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi"            %%% "utest"                  % "0.7.1" % "test",
+    "com.lihaoyi"            %%% "utest"                  % "0.7.3" % "test",
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
   )
 )
@@ -104,7 +104,7 @@ lazy val diodeCore = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(
-    crossScalaVersions += "2.13.0",
+    crossScalaVersions += "2.13.1",
     name := "diode-core",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
   )
@@ -120,7 +120,7 @@ lazy val diodeData = crossProject(JSPlatform, JVMPlatform)
   .in(file("diode-data"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
-  .settings(name := "diode-data", crossScalaVersions += "2.13.0")
+  .settings(name := "diode-data", crossScalaVersions += "2.13.1")
   .jsSettings(scalacOptions ++= sourceMapSetting.value)
   .jvmSettings()
   .dependsOn(diodeCore)
@@ -136,7 +136,7 @@ lazy val diode = crossProject(JSPlatform, JVMPlatform)
   .settings(publishSettings: _*)
   .settings(
     name := "diode",
-    crossScalaVersions += "2.13.0",
+    crossScalaVersions += "2.13.1",
     test := {}
   )
   .dependsOn(diodeCore, diodeData)
@@ -152,10 +152,10 @@ lazy val diodeDevtools = crossProject(JSPlatform, JVMPlatform)
   .settings(publishSettings: _*)
   .settings(
     name := "diode-devtools",
-    crossScalaVersions += "2.13.0"
+    crossScalaVersions += "2.13.1"
   )
   .jsSettings(
-    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "0.9.7"),
+    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "0.9.8"),
     scalacOptions ++= sourceMapSetting.value
   )
   .jvmSettings()
@@ -180,18 +180,22 @@ lazy val diodeReact = project
   .dependsOn(diodeJS)
   .enablePlugins(ScalaJSPlugin)
 
+val coreProjects = Seq[ProjectReference](
+  diodeJS,
+  diodeJVM,
+  diodeCoreJS,
+  diodeCoreJVM,
+  diodeDataJS,
+  diodeDataJVM,
+  diodeDevToolsJS,
+  diodeDevToolsJVM
+)
+
+val projects: Seq[ProjectReference] =
+  if (scalaJSVersion.startsWith("0.6")) coreProjects ++ diodeReact.referenced else coreProjects
+
 lazy val root = preventPublication(project.in(file(".")))
   .settings(
     commonSettings
   )
-  .aggregate(
-    diodeJS,
-    diodeJVM,
-    diodeCoreJS,
-    diodeCoreJVM,
-    diodeDataJS,
-    diodeDataJVM,
-    diodeReact,
-    diodeDevToolsJS,
-    diodeDevToolsJVM
-  )
+  .aggregate(projects: _*)

--- a/diode-core/shared/src/main/scala/diode/Circuit.scala
+++ b/diode-core/shared/src/main/scala/diode/Circuit.scala
@@ -4,7 +4,6 @@ import diode.macros.GenLens
 
 import scala.annotation.implicitNotFound
 import scala.collection.immutable.Queue
-import scala.language.higherKinds
 
 /**
   * The `ActionType` type class is used to verify that only valid actions are dispatched. An implicit instance of

--- a/diode-core/shared/src/main/scala/diode/ModelRW.scala
+++ b/diode-core/shared/src/main/scala/diode/ModelRW.scala
@@ -2,8 +2,6 @@ package diode
 
 import diode.macros.GenLens
 
-import scala.language.higherKinds
-
 /**
   * A read-only version of ModelR that doesn't know about the root model.
   *

--- a/diode-core/shared/src/main/scala/diode/Monad.scala
+++ b/diode-core/shared/src/main/scala/diode/Monad.scala
@@ -1,7 +1,5 @@
 package diode
 
-import scala.language.higherKinds
-
 /**
   * Defines a Diode specific Monad for traversing models with `Option`s etc.
   */

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
-  val library  = "1.1.6"
+  val library  = "1.1.7"
   val sjsReact = "1.4.2"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0-RC2")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 


### PR DESCRIPTION
# Changes

- Allow cross-building for any ScalaJS version - default is 1.0.0-RC2
- The build uses the `SCALAJS_VERSION` environment variable to get the scala.js plugin version for the build
- The diode-react sub-project is now only built for 0.6.x builds
- Bump scala cross versions to 2.12.10 and 2.13.1
- Adjust for change where higher kinds are directly supported in 2.13.1
