### PR TITLE
update to SJS 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ node_js:
 - oraclejdk8
 script:
 - SCALAJS_VERSION="0.6.31" sbt +test
-- SCALAJS_VERSION="1.0.0-RC2" sbt +test
+- SCALAJS_VERSION="1.0.0" sbt +test
 # Tricks to avoid unnecessary cache updates, from
 # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
 - find $HOME/.sbt -name "*.lock" | xargs rm
 - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 cache:
   directories:
+    - $HOME/.coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+
+## 1.1.8
+- update build/dependencies to support SJS 1.0.0
+
 ## 1.1.7
 - Allow cross-building for any ScalaJS version - default is 1.0.0-RC2
 - The build uses the `SCALAJS_VERSION` environment variable to get the scala.js plugin version for the build

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Full documentation [available here](https://diode.suzaku.io).
 Add following dependency declaration to your Scala project.
 
 ```scala
-"io.suzaku" %% "diode" % "1.1.7"
+"io.suzaku" %% "diode" % "1.1.8"
 ```
 
 In a Scala.js project the dependency looks like this.
 
 ```scala
-"io.suzaku" %%% "diode" % "1.1.7"
+"io.suzaku" %%% "diode" % "1.1.8"
 ```
 
 Starting with version "1.1.6" diode has dropped support for Scala 2.11. If you need 2.11 support use version "1.1.5"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-import sbt._
-import Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
+import sbt.Keys._
+import sbt._
 // shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
@@ -32,8 +32,8 @@ val commonSettings = Seq(
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi"            %%% "utest"                  % "0.7.3" % "test",
-    "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
+    "com.lihaoyi"            %%% "utest"                  % "0.7.4" % "test",
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4"
   )
 )
 
@@ -149,10 +149,10 @@ lazy val diodeDevtools = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(
-    name := "diode-devtools",
+    name := "diode-devtools"
   )
   .jsSettings(
-    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "0.9.8"),
+    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "1.0.0"),
     scalacOptions ++= sourceMapSetting.value
   )
   .jvmSettings()
@@ -162,7 +162,7 @@ lazy val diodeDevToolsJS = diodeDevtools.js
 
 lazy val diodeDevToolsJVM = diodeDevtools.jvm
 
-lazy val diodeReact = project
+lazy val diodeReact: Project = project
   .in(file("diode-react"))
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
@@ -177,7 +177,7 @@ lazy val diodeReact = project
   .dependsOn(diodeJS)
   .enablePlugins(ScalaJSPlugin)
 
-val coreProjects = Seq[ProjectReference](
+lazy val coreProjects = Seq[ProjectReference](
   diodeJS,
   diodeJVM,
   diodeCoreJS,
@@ -188,19 +188,9 @@ val coreProjects = Seq[ProjectReference](
   diodeDevToolsJVM
 )
 
-val allProjects = Seq[ProjectReference](
-  diodeJS,
-  diodeJVM,
-  diodeCoreJS,
-  diodeCoreJVM,
-  diodeDataJS,
-  diodeDataJVM,
-  diodeDevToolsJS,
-  diodeDevToolsJVM,
-  diodeReact
-)
+lazy val allProjects = coreProjects :+ diodeReact.project
 
-val projects: Seq[ProjectReference] =
+lazy val projects: Seq[ProjectReference] =
   if (scalaJSVersion.startsWith("0.6")) allProjects else coreProjects
 
 lazy val root = preventPublication(project.in(file(".")))

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
-  val library  = "1.1.7"
+  val library  = "1.1.8"
   val sjsReact = "1.6.0"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0-RC2")
+val scalaJSVersion = sys.env.getOrElse("SCALAJS_VERSION", "1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
Still supports SJS  0.6.X including diode-react subproject.