### PR TITLE
Update scalafmt to 3.0.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,17 @@
+version = 3.0.2
 style = default
-align = more
+align {
+  preset = "more"
+  openParenCallSite = false
+  openParenDefnSite = true
+}
 maxColumn = 125
 rewrite.rules = [SortImports]
 project.git = true
+docstrings {
+  style = SpaceAsterisk
+  blankFirstLine = yes
+}
+newlines {
+  beforeCurlyLambdaParams = multilineWithCaseOnly
+}

--- a/diode-core/shared/src/main/scala/diode/ActionHandler.scala
+++ b/diode-core/shared/src/main/scala/diode/ActionHandler.scala
@@ -9,7 +9,8 @@ import scala.language.implicitConversions
 /**
   * Base class for all action handlers.
   *
-  * @param modelRW Model reader/writer for the actions this handler processes.
+  * @param modelRW
+  *   Model reader/writer for the actions this handler processes.
   */
 abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
 
@@ -47,8 +48,8 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
     ModelUpdate(modelRW.updatedWith(currentModel, newValue))
 
   /**
-    * Helper function to create a `ModelUpdateSilent` result from a new value. Being silent, the
-    * update prevents any calls to listeners.
+    * Helper function to create a `ModelUpdateSilent` result from a new value. Being silent, the update prevents any calls to
+    * listeners.
     *
     * @param newValue
     * @return
@@ -67,8 +68,8 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
     ModelUpdateEffect(modelRW.updatedWith(currentModel, newValue), effect)
 
   /**
-    * Helper function to create a `ModelUpdateSilentEffect` result from a new value and an effect. Being silent, the
-    * update prevents any calls to listeners.
+    * Helper function to create a `ModelUpdateSilentEffect` result from a new value and an effect. Being silent, the update
+    * prevents any calls to listeners.
     *
     * @param newValue
     * @param effect
@@ -97,8 +98,10 @@ abstract class ActionHandler[M, T](val modelRW: ModelRW[M, T]) {
   /**
     * Helper function to create a delayed effect.
     *
-    * @param delay How much to delay the effect.
-    * @param f     Result of the effect
+    * @param delay
+    *   How much to delay the effect.
+    * @param f
+    *   Result of the effect
     */
   def runAfter[A: ActionType](delay: FiniteDuration)(f: => A)(implicit runner: RunAfter, ec: ExecutionContext): Effect =
     Effect(runner.runAfter(delay)(f))

--- a/diode-core/shared/src/main/scala/diode/Circuit.scala
+++ b/diode-core/shared/src/main/scala/diode/Circuit.scala
@@ -9,15 +9,17 @@ import scala.collection.immutable.Queue
   * The `ActionType` type class is used to verify that only valid actions are dispatched. An implicit instance of
   * `ActionType[A]` must be in scope when calling dispatch methods or creating effects that return actions.
   *
-  * `ActionType` is contravariant, which means it's enough to have an instance of `ActionType` for a common supertype
-  * to be able to dispatch actions of its subtypes. For example providing an instance of `ActionType[Action]` allows
-  * dispatching any class that is a subtype of `Action`.
+  * `ActionType` is contravariant, which means it's enough to have an instance of `ActionType` for a common supertype to be
+  * able to dispatch actions of its subtypes. For example providing an instance of `ActionType[Action]` allows dispatching
+  * any class that is a subtype of `Action`.
   *
-  * @tparam A Action type
+  * @tparam A
+  *   Action type
   */
 @implicitNotFound(
   msg =
-    "Cannot find an ActionType type class for action of type ${A}. Make sure to provide an implicit ActionType for dispatched actions.")
+    "Cannot find an ActionType type class for action of type ${A}. Make sure to provide an implicit ActionType for dispatched actions."
+)
 trait ActionType[-A]
 
 trait Dispatcher {
@@ -27,9 +29,9 @@ trait Dispatcher {
 }
 
 /**
-  * Base trait for actions. Use this as a basis for your action class hierarchy to get an automatic
-  * type class instance of `ActionType[Action]`. Note that this trait is just a helper, you don't need
-  * to use it for your actions as you can always define your own `ActionType` instances for your action types.
+  * Base trait for actions. Use this as a basis for your action class hierarchy to get an automatic type class instance of
+  * `ActionType[Action]`. Note that this trait is just a helper, you don't need to use it for your actions as you can always
+  * define your own `ActionType` instances for your action types.
   */
 trait Action
 
@@ -40,7 +42,8 @@ object Action {
 /**
   * A batch of actions. These actions are dispatched in a batch, without calling listeners in-between the dispatches.
   *
-  * @param actions Sequence of actions to dispatch
+  * @param actions
+  *   Sequence of actions to dispatch
   */
 class ActionBatch private (val actions: Seq[Any]) extends Action {
   def :+[A: ActionType](action: A): ActionBatch =
@@ -147,8 +150,9 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
 
   private def buildProcessChain = {
     // chain processing functions
-    processors.reverse.foldLeft(process _)(
-      (next, processor) => (action: Any) => processor.process(this, action, next, model))
+    processors.reverse.foldLeft(process _)((next, processor) =>
+      (action: Any) => processor.process(this, action, next, model)
+    )
   }
 
   private def baseHandler(action: Any) = action match {
@@ -168,8 +172,10 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   /**
     * Zoom into the model using the `get` function
     *
-    * @param get Function that returns the part of the model you are interested in
-    * @return A `ModelR[T]` giving you read-only access to part of the model
+    * @param get
+    *   Function that returns the part of the model you are interested in
+    * @return
+    *   A `ModelR[T]` giving you read-only access to part of the model
     */
   def zoom[T](get: M => T)(implicit feq: FastEq[_ >: T]): ModelR[M, T] =
     modelRW.zoom[T](get)
@@ -183,45 +189,49 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   /**
     * Zoom into the model using `get` and `set` functions
     *
-    * @param get Function that returns the part of the model you are interested in
-    * @param set Function that updates the part of the model you are interested in
-    * @return A `ModelRW[T]` giving you read/update access to part of the model
+    * @param get
+    *   Function that returns the part of the model you are interested in
+    * @param set
+    *   Function that updates the part of the model you are interested in
+    * @return
+    *   A `ModelRW[T]` giving you read/update access to part of the model
     */
   def zoomRW[T](get: M => T)(set: (M, T) => M)(implicit feq: FastEq[_ >: T]): ModelRW[M, T] = modelRW.zoomRW(get)(set)
 
-  def zoomMapRW[F[_], A, B](fa: M => F[A])(f: A => B)(set: (M, F[B]) => M)(implicit monad: Monad[F],
-                                                                           feq: FastEq[_ >: B]): ModelRW[M, F[B]] =
+  def zoomMapRW[F[_], A, B](fa: M => F[A])(f: A => B)(
+      set: (M, F[B]) => M
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelRW[M, F[B]] =
     modelRW.zoomMapRW(fa)(f)(set)
 
-  def zoomFlatMapRW[F[_], A, B](fa: M => F[A])(f: A => F[B])(set: (M, F[B]) => M)(implicit monad: Monad[F],
-                                                                                  feq: FastEq[_ >: B]): ModelRW[M, F[B]] =
+  def zoomFlatMapRW[F[_], A, B](fa: M => F[A])(f: A => F[B])(
+      set: (M, F[B]) => M
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelRW[M, F[B]] =
     modelRW.zoomFlatMapRW(fa)(f)(set)
 
   def zoomTo[T](field: M => T): ModelRW[M, T] = macro GenLens.generate[M, M, T]
 
   /**
-    * Subscribes to listen to changes in the model. By providing a `cursor` you can limit
-    * what part of the model must change for your listener to be called. If omitted, all changes
-    * result in a call.
+    * Subscribes to listen to changes in the model. By providing a `cursor` you can limit what part of the model must change
+    * for your listener to be called. If omitted, all changes result in a call.
     *
-    * @param cursor   Model reader returning the part of the model you are interested in.
-    * @param listener Function to be called when model is updated. The listener function gets
-    *                 the model reader as a parameter.
-    * @return A function to unsubscribe your listener
+    * @param cursor
+    *   Model reader returning the part of the model you are interested in.
+    * @param listener
+    *   Function to be called when model is updated. The listener function gets the model reader as a parameter.
+    * @return
+    *   A function to unsubscribe your listener
     */
   def subscribe[T](cursor: ModelR[M, T])(listener: ModelRO[T] => Unit): () => Unit = {
     this.synchronized {
       listenerId += 1
       val id = listenerId
       listeners += id -> Subscription(listener, cursor, cursor.eval(model))
-      () =>
-        this.synchronized(listeners -= id)
+      () => this.synchronized(listeners -= id)
     }
   }
 
   /**
-    * Adds a new `ActionProcessor[M]` to the action processing chain. The processor is called for
-    * every dispatched action.
+    * Adds a new `ActionProcessor[M]` to the action processing chain. The processor is called for every dispatched action.
     *
     * @param processor
     */
@@ -245,25 +255,28 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   }
 
   /**
-    * Handle a fatal error. Override this function to do something with exceptions that
-    * occur while dispatching actions.
+    * Handle a fatal error. Override this function to do something with exceptions that occur while dispatching actions.
     *
-    * @param action Action that caused the exception
-    * @param e      Exception that was thrown
+    * @param action
+    *   Action that caused the exception
+    * @param e
+    *   Exception that was thrown
     */
   def handleFatal(action: Any, e: Throwable): Unit = throw e
 
   /**
     * Handle a non-fatal error, such as dispatching an action with no action handler.
     *
-    * @param msg Error message
+    * @param msg
+    *   Error message
     */
   def handleError(msg: String): Unit = throw new Exception(s"handleError called with: $msg")
 
   /**
-    *
-    * @param action the action that caused the effects
-    * @param error the Exception that was encountered while processing the effects
+    * @param action
+    *   the action that caused the effects
+    * @param error
+    *   the Exception that was encountered while processing the effects
     */
   def handleEffectProcessingError[A](action: A, error: Throwable): Unit = {
     handleError(s"Error in processing effects for action $action: $error")
@@ -281,7 +294,8 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   /**
     * The final action processor that does actual action handling.
     *
-    * @param action Action to be handled
+    * @param action
+    *   Action to be handled
     * @return
     */
   private def process(action: Any): ActionResult[M] = {
@@ -289,8 +303,8 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   }
 
   /**
-    * Composes multiple handlers into a single handler. Processing stops as soon as a handler is able to handle
-    * the action. If none of them handle the action, `None` is returned
+    * Composes multiple handlers into a single handler. Processing stops as soon as a handler is able to handle the action.
+    * If none of them handle the action, `None` is returned
     */
   def composeHandlers(handlers: HandlerFunction*): HandlerFunction =
     (model, action) => {
@@ -303,9 +317,8 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   def combineHandlers(handlers: HandlerFunction*): HandlerFunction = composeHandlers(handlers: _*)
 
   /**
-    * Folds multiple handlers into a single function so that each handler is called
-    * in turn and an updated model is passed on to the next handler. Returned `ActionResult` contains the final model
-    * and combined effects.
+    * Folds multiple handlers into a single function so that each handler is called in turn and an updated model is passed on
+    * to the next handler. Returned `ActionResult` contains the final model and combined effects.
     */
   def foldHandlers(handlers: HandlerFunction*): HandlerFunction =
     (initialModel, action) => {
@@ -338,7 +351,8 @@ trait Circuit[M <: AnyRef] extends Dispatcher {
   /**
     * Dispatch the action, call change listeners when completed
     *
-    * @param action Action to dispatch
+    * @param action
+    *   Action to dispatch
     */
   def dispatch[A: ActionType](action: A): Unit = {
     this.synchronized {

--- a/diode-core/shared/src/main/scala/diode/Effect.scala
+++ b/diode-core/shared/src/main/scala/diode/Effect.scala
@@ -11,8 +11,10 @@ trait Effect {
   /**
     * Runs the effect and dispatches the result of the effect.
     *
-    * @param dispatch Function to dispatch the effect result with.
-    * @return A future that completes when the effect completes.
+    * @param dispatch
+    *   Function to dispatch the effect result with.
+    * @return
+    *   A future that completes when the effect completes.
     */
   def run(dispatch: Any => Unit): Future[Unit]
 
@@ -47,17 +49,15 @@ trait Effect {
   def after(delay: FiniteDuration)(implicit runner: RunAfter): Effect
 
   /**
-    * Creates a new effect by applying a function to the successful result of
-    * this effect. If this effect is completed with an exception then the new
-    * effect will also contain this exception.
+    * Creates a new effect by applying a function to the successful result of this effect. If this effect is completed with
+    * an exception then the new effect will also contain this exception.
     */
   def map[B: ActionType](g: Any => B): Effect
 
   /**
-    * Creates a new effect by applying a function to the successful result of
-    * this effect, and returns the result of the function as the new future.
-    * If this effect is completed with an exception then the new
-    * effect will also contain this exception.
+    * Creates a new effect by applying a function to the successful result of this effect, and returns the result of the
+    * function as the new future. If this effect is completed with an exception then the new effect will also contain this
+    * exception.
     */
   def flatMap[B: ActionType](g: Any => Future[B]): Effect
 
@@ -92,10 +92,11 @@ abstract class EffectBase(val ec: ExecutionContext) extends Effect { self =>
 }
 
 /**
-  * Wraps a function to be executed later. Function must return a `Future[A]` and the returned
-  * action is automatically dispatched when `run` is called.
+  * Wraps a function to be executed later. Function must return a `Future[A]` and the returned action is automatically
+  * dispatched when `run` is called.
   *
-  * @param f The effect function, returning a `Future[A]`
+  * @param f
+  *   The effect function, returning a `Future[A]`
   */
 class EffectSingle[A] private[diode] (f: () => Future[A], ec: ExecutionContext) extends EffectBase(ec) {
   override def run(dispatch: Any => Unit) = f().map(dispatch)(ec)
@@ -104,11 +105,13 @@ class EffectSingle[A] private[diode] (f: () => Future[A], ec: ExecutionContext) 
 }
 
 /**
-  * Wraps multiple `Effects` to be executed later. Effects are executed in the order they appear and the
-  * next effect is run only after the previous has completed. If an effect fails, the execution stops.
+  * Wraps multiple `Effects` to be executed later. Effects are executed in the order they appear and the next effect is run
+  * only after the previous has completed. If an effect fails, the execution stops.
   *
-  * @param head First effect to be run.
-  * @param tail Rest of the effects.
+  * @param head
+  *   First effect to be run.
+  * @param tail
+  *   Rest of the effects.
   */
 class EffectSeq(head: Effect, tail: Seq[Effect], ec: ExecutionContext) extends EffectBase(ec) {
   private def executeWith[A](f: Effect => Future[A]): Future[A] =
@@ -141,8 +144,10 @@ class EffectSeq(head: Effect, tail: Seq[Effect], ec: ExecutionContext) extends E
 /**
   * Wraps multiple `Effects` to be executed later. Effects are executed in parallel without any ordering.
   *
-  * @param head First effect to be run.
-  * @param tail Rest of the effects.
+  * @param head
+  *   First effect to be run.
+  * @param tail
+  *   Rest of the effects.
   */
 class EffectSet(val head: Effect, val tail: Set[Effect], ec: ExecutionContext)
     extends EffectBase(ec)
@@ -174,8 +179,8 @@ object Effect {
     new EffectSingle(() => f, ec)
 
   /**
-    * Converts a lazy action value into an effect. Typically used in combination with other effects or
-    * with `after` to delay execution.
+    * Converts a lazy action value into an effect. Typically used in combination with other effects or with `after` to delay
+    * execution.
     */
   def action[A: ActionType](action: => A)(implicit ec: ExecutionContext): EffectSingle[A] =
     new EffectSingle(() => Future.successful(action), ec)

--- a/diode-core/shared/src/main/scala/diode/ModelRW.scala
+++ b/diode-core/shared/src/main/scala/diode/ModelRW.scala
@@ -5,7 +5,8 @@ import diode.macros.GenLens
 /**
   * A read-only version of ModelR that doesn't know about the root model.
   *
-  * @tparam S Type of the reader value
+  * @tparam S
+  *   Type of the reader value
   */
 trait ModelRO[S] {
 
@@ -28,7 +29,8 @@ trait ModelRO[S] {
   /**
     * Checks if `that` is equal to `this` using an appropriate equality check
     *
-    * @param that Value to compare with
+    * @param that
+    *   Value to compare with
     * @return
     */
   def ===(that: S): Boolean
@@ -38,24 +40,27 @@ trait ModelRO[S] {
   /**
     * Zooms into the model using the provided accessor function
     *
-    * @param get Function to go from current reader to a new value
+    * @param get
+    *   Function to go from current reader to a new value
     */
   def zoom[T](get: S => T)(implicit feq: FastEq[_ >: T]): NewR[T]
 
   /**
-    * Maps over current reader into a new value provided by `f`. Reader type `S` must be of type `F[A]`,
-    * for example `Option[A]`.
+    * Maps over current reader into a new value provided by `f`. Reader type `S` must be of type `F[A]`, for example
+    * `Option[A]`.
     *
-    * @param f The function to apply
+    * @param f
+    *   The function to apply
     */
   def map[F[_], A, B](f: A => B)(implicit ev: S =:= F[A], monad: Monad[F], feq: FastEq[_ >: B]): NewR[F[B]] =
     zoomMap((_: S) => ev(value))(f)
 
   /**
-    * FlatMaps over current reader into a new value provided by `f`. Reader type `S` must be of type `F[A]`,
-    * for example `Option[A]`.
+    * FlatMaps over current reader into a new value provided by `f`. Reader type `S` must be of type `F[A]`, for example
+    * `Option[A]`.
     *
-    * @param f The function to apply, must return a value of type `F[B]`
+    * @param f
+    *   The function to apply, must return a value of type `F[B]`
     */
   def flatMap[F[_], A, B](f: A => F[B])(implicit ev: S =:= F[A], monad: Monad[F], feq: FastEq[_ >: B]): NewR[F[B]] =
     zoomFlatMap((_: S) => ev(value))(f)
@@ -63,16 +68,20 @@ trait ModelRO[S] {
   /**
     * Zooms into the model and maps over the zoomed value, which must be of type `F[A]`
     *
-    * @param fa Zooming function
-    * @param f  The function to apply
+    * @param fa
+    *   Zooming function
+    * @param f
+    *   The function to apply
     */
   def zoomMap[F[_], A, B](fa: S => F[A])(f: A => B)(implicit monad: Monad[F], feq: FastEq[_ >: B]): NewR[F[B]]
 
   /**
     * Zooms into the model and flatMaps over the zoomed value, which must be of type `F[A]`
     *
-    * @param fa Zooming function
-    * @param f  The function to apply, must return a value of type `F[B]`
+    * @param fa
+    *   Zooming function
+    * @param f
+    *   The function to apply, must return a value of type `F[B]`
     */
   def zoomFlatMap[F[_], A, B](fa: S => F[A])(f: A => F[B])(implicit monad: Monad[F], feq: FastEq[_ >: B]): NewR[F[B]]
 }
@@ -80,8 +89,10 @@ trait ModelRO[S] {
 /**
   * Base trait for all model readers
   *
-  * @tparam M Type of the base model
-  * @tparam S Type of the reader value
+  * @tparam M
+  *   Type of the base model
+  * @tparam S
+  *   Type of the reader value
   */
 trait ModelR[M, S] extends ModelRO[S] {
   override type NewR[T] = ModelR[M, T]
@@ -97,10 +108,11 @@ trait ModelR[M, S] extends ModelRO[S] {
   def root: ModelR[M, M]
 
   /**
-    * Combines this reader with another reader to provide a new reader returning a tuple of the values
-    * of the two original readers.
+    * Combines this reader with another reader to provide a new reader returning a tuple of the values of the two original
+    * readers.
     *
-    * @param that The other reader
+    * @param that
+    *   The other reader
     */
   def zip[SS](that: ModelR[M, SS])(implicit feqS: FastEq[_ >: S], feqSS: FastEq[_ >: SS]): ModelR[M, (S, SS)]
 }
@@ -108,8 +120,10 @@ trait ModelR[M, S] extends ModelRO[S] {
 /**
   * Base trait for all model writers
   *
-  * @tparam M Type of the base model
-  * @tparam S Type of the reader/writer value
+  * @tparam M
+  *   Type of the base model
+  * @tparam S
+  *   Type of the reader/writer value
   */
 trait ModelRW[M, S] extends ModelR[M, S] {
 
@@ -124,41 +138,53 @@ trait ModelRW[M, S] extends ModelR[M, S] {
   def updatedWith(model: M, newValue: S): M
 
   /**
-    * Zooms into the model using the provided `get` function. The `set` function is used to
-    * update the model with a new value.
+    * Zooms into the model using the provided `get` function. The `set` function is used to update the model with a new
+    * value.
     *
-    * @param get Function to go from current reader to a new value
-    * @param set Function to update the model with a new value
+    * @param get
+    *   Function to go from current reader to a new value
+    * @param set
+    *   Function to update the model with a new value
     */
   def zoomRW[T](get: S => T)(set: (S, T) => S)(implicit feq: FastEq[_ >: T]): ModelRW[M, T]
 
   /**
-    * Zooms into the model and maps over the zoomed value, which must be of type `F[A]`. The `set` function is used to
-    * update the model with a new value.
+    * Zooms into the model and maps over the zoomed value, which must be of type `F[A]`. The `set` function is used to update
+    * the model with a new value.
     *
-    * @param fa  Zooming function
-    * @param f   The function to apply
-    * @param set Function to update the model with a new value
+    * @param fa
+    *   Zooming function
+    * @param f
+    *   The function to apply
+    * @param set
+    *   Function to update the model with a new value
     */
-  def zoomMapRW[F[_], A, B](fa: S => F[A])(f: A => B)(set: (S, F[B]) => S)(implicit monad: Monad[F],
-                                                                           feq: FastEq[_ >: B]): ModelRW[M, F[B]]
+  def zoomMapRW[F[_], A, B](fa: S => F[A])(f: A => B)(
+      set: (S, F[B]) => S
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelRW[M, F[B]]
 
   /**
     * Zooms into the model and flatMaps over the zoomed value, which must be of type `F[A]`. The `set` function is used to
     * update the model with a new value.
     *
-    * @param fa  Zooming function
-    * @param f   The function to apply
-    * @param set Function to update the model with a new value
+    * @param fa
+    *   Zooming function
+    * @param f
+    *   The function to apply
+    * @param set
+    *   Function to update the model with a new value
     */
-  def zoomFlatMapRW[F[_], A, B](fa: S => F[A])(f: A => F[B])(set: (S, F[B]) => S)(implicit monad: Monad[F],
-                                                                                  feq: FastEq[_ >: B]): ModelRW[M, F[B]]
+  def zoomFlatMapRW[F[_], A, B](fa: S => F[A])(f: A => F[B])(
+      set: (S, F[B]) => S
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelRW[M, F[B]]
 
   /**
-    * An easier way to zoom into a RW model by just specifying a single chained accessor for the field. This works for cases like
-    * `zoomTo(_.a.b.c)` but not for more complex cases such as `zoomTo(_.a.b(0))`. Uses a macro to generate appropriate update function.
+    * An easier way to zoom into a RW model by just specifying a single chained accessor for the field. This works for cases
+    * like `zoomTo(_.a.b.c)` but not for more complex cases such as `zoomTo(_.a.b(0))`. Uses a macro to generate appropriate
+    * update function.
     *
-    * @param field Field to access in the model
+    * @param field
+    *   Field to access in the model
     */
   def zoomTo[T](field: S => T): ModelRW[M, T] = macro GenLens.generate[M, S, T]
 }
@@ -166,8 +192,10 @@ trait ModelRW[M, S] extends ModelR[M, S] {
 /**
   * Implements common functionality for all model readers
   *
-  * @tparam M Type of the base model
-  * @tparam S Type of the reader value
+  * @tparam M
+  *   Type of the base model
+  * @tparam S
+  *   Type of the reader value
   */
 trait BaseModelR[M, S] extends ModelR[M, S] {
   override def eval(model: M): S
@@ -180,12 +208,14 @@ trait BaseModelR[M, S] extends ModelR[M, S] {
   override def zip[SS](that: ModelR[M, SS])(implicit feqS: FastEq[_ >: S], feqSS: FastEq[_ >: SS]) =
     new ZipModelR[M, S, SS](root, eval, that.eval)
 
-  override def zoomMap[F[_], A, B](fa: S => F[A])(f: A => B)(implicit monad: Monad[F],
-                                                             feq: FastEq[_ >: B]): ModelR[M, F[B]] =
+  override def zoomMap[F[_], A, B](fa: S => F[A])(
+      f: A => B
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelR[M, F[B]] =
     new MapModelR(root, fa compose eval, f)
 
-  override def zoomFlatMap[F[_], A, B](fa: S => F[A])(f: A => F[B])(implicit monad: Monad[F],
-                                                                    feq: FastEq[_ >: B]): ModelR[M, F[B]] =
+  override def zoomFlatMap[F[_], A, B](fa: S => F[A])(
+      f: A => F[B]
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]): ModelR[M, F[B]] =
     new FlatMapModelR(root, fa compose eval, f)
 }
 
@@ -233,9 +263,10 @@ trait MappedModelR[F[_], M, B] { self: ModelR[M, F[B]] =>
 /**
   * Model reader for a mapped value
   */
-class MapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A => B)(implicit val monad: Monad[F],
-                                                                                  val feq: FastEq[_ >: B])
-    extends BaseModelR[M, F[B]]
+class MapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A => B)(implicit
+    val monad: Monad[F],
+    val feq: FastEq[_ >: B]
+) extends BaseModelR[M, F[B]]
     with MappedModelR[F, M, B] {
 
   override protected def mapValue = monad.map(get(root.value))(f)
@@ -244,9 +275,10 @@ class MapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A => B
 /**
   * Model reader for a flatMapped value
   */
-class FlatMapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A => F[B])(implicit val monad: Monad[F],
-                                                                                         val feq: FastEq[_ >: B])
-    extends BaseModelR[M, F[B]]
+class FlatMapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A => F[B])(implicit
+    val monad: Monad[F],
+    val feq: FastEq[_ >: B]
+) extends BaseModelR[M, F[B]]
     with MappedModelR[F, M, B] {
 
   override protected def mapValue = monad.flatMap(get(root.value))(f)
@@ -255,9 +287,10 @@ class FlatMapModelR[F[_], M, A, B](val root: ModelR[M, M], get: M => F[A], f: A 
 /**
   * Model reader for two zipped readers
   */
-class ZipModelR[M, S, SS](val root: ModelR[M, M], get1: M => S, get2: M => SS)(implicit feqS: FastEq[_ >: S],
-                                                                               feqSS: FastEq[_ >: SS])
-    extends BaseModelR[M, (S, SS)] {
+class ZipModelR[M, S, SS](val root: ModelR[M, M], get1: M => S, get2: M => SS)(implicit
+    feqS: FastEq[_ >: S],
+    feqSS: FastEq[_ >: SS]
+) extends BaseModelR[M, (S, SS)] {
   // initial value for zipped
   private var zipped = (get1(root.value), get2(root.value))
 
@@ -282,19 +315,23 @@ class ZipModelR[M, S, SS](val root: ModelR[M, M], get1: M => S, get2: M => SS)(i
 /**
   * Implements common functionality for all reader/writers
   *
-  * @tparam M Type of the base model
-  * @tparam S Type of the reader/writer value
+  * @tparam M
+  *   Type of the base model
+  * @tparam S
+  *   Type of the reader/writer value
   */
 trait BaseModelRW[M, S] extends ModelRW[M, S] with BaseModelR[M, S] {
   override def zoomRW[U](get: S => U)(set: (S, U) => S)(implicit feq: FastEq[_ >: U]) =
     new ZoomModelRW[M, U](root, get compose eval, (s, u) => updatedWith(s, set(eval(s), u)))
 
-  override def zoomMapRW[F[_], A, B](fa: S => F[A])(f: A => B)(set: (S, F[B]) => S)(implicit monad: Monad[F],
-                                                                                    feq: FastEq[_ >: B]) =
+  override def zoomMapRW[F[_], A, B](fa: S => F[A])(f: A => B)(
+      set: (S, F[B]) => S
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]) =
     new MapModelRW(root, fa compose eval, f)((s, u) => updatedWith(s, set(eval(s), u)))
 
-  override def zoomFlatMapRW[F[_], A, B](fa: S => F[A])(f: A => F[B])(set: (S, F[B]) => S)(implicit monad: Monad[F],
-                                                                                           feq: FastEq[_ >: B]) =
+  override def zoomFlatMapRW[F[_], A, B](fa: S => F[A])(f: A => F[B])(
+      set: (S, F[B]) => S
+  )(implicit monad: Monad[F], feq: FastEq[_ >: B]) =
     new FlatMapModelRW(root, fa compose eval, f)((s, u) => updatedWith(s, set(eval(s), u)))
 
   override def updated(newValue: S) = updatedWith(root.value, newValue)
@@ -323,9 +360,10 @@ class ZoomModelRW[M, S](root: ModelR[M, M], get: M => S, set: (M, S) => M)(impli
 /**
   * Model reader/writer for a mapped value
   */
-class MapModelRW[F[_], M, A, B](root: ModelR[M, M], get: M => F[A], f: A => B)(set: (M, F[B]) => M)(implicit monad: Monad[F],
-                                                                                                    feq: FastEq[_ >: B])
-    extends MapModelR(root, get, f)
+class MapModelRW[F[_], M, A, B](root: ModelR[M, M], get: M => F[A], f: A => B)(set: (M, F[B]) => M)(implicit
+    monad: Monad[F],
+    feq: FastEq[_ >: B]
+) extends MapModelR(root, get, f)
     with BaseModelRW[M, F[B]] {
   override def updatedWith(model: M, value: F[B]) = set(model, value)
 }
@@ -333,10 +371,10 @@ class MapModelRW[F[_], M, A, B](root: ModelR[M, M], get: M => F[A], f: A => B)(s
 /**
   * Model reader/writer for a flatMapped value
   */
-class FlatMapModelRW[F[_], M, A, B](root: ModelR[M, M], get: M => F[A], f: A => F[B])(set: (M, F[B]) => M)(
-    implicit monad: Monad[F],
-    feq: FastEq[_ >: B])
-    extends FlatMapModelR(root, get, f)
+class FlatMapModelRW[F[_], M, A, B](root: ModelR[M, M], get: M => F[A], f: A => F[B])(set: (M, F[B]) => M)(implicit
+    monad: Monad[F],
+    feq: FastEq[_ >: B]
+) extends FlatMapModelR(root, get, f)
     with BaseModelRW[M, F[B]] {
   override def updatedWith(model: M, value: F[B]) = set(model, value)
 }

--- a/diode-core/shared/src/main/scala/diode/util/Retry.scala
+++ b/diode-core/shared/src/main/scala/diode/util/Retry.scala
@@ -15,7 +15,8 @@ trait RetryPolicy {
   /**
     * Checks if retry should be attempted.
     *
-    * @param reason Reason for failure leading to this retry. Used for filtering.
+    * @param reason
+    *   Reason for failure leading to this retry. Used for filtering.
     * @return
     */
   def canRetry(reason: Throwable): Boolean
@@ -23,8 +24,10 @@ trait RetryPolicy {
   /**
     * Retries an effect. Returns `Left` if retry is not possible and `Right[(RetryPolicy, Effects)]` if it is.
     *
-    * @param reason Reason for failure leading to this retry. Used for filtering.
-    * @param effectProvider Effect to be retried.
+    * @param reason
+    *   Reason for failure leading to this retry. Used for filtering.
+    * @param effectProvider
+    *   Effect to be retried.
     * @return
     */
   def retry[T <: AnyRef](reason: Throwable, effectProvider: RetryPolicy => Effect): Either[Throwable, (RetryPolicy, Effect)]
@@ -47,8 +50,10 @@ object Retry {
   /**
     * Retries a max of `retriesLeft` times immediately following a failure.
     *
-    * @param retriesLeft Number of retries
-    * @param filter A filter to check if the cause of failure should prevent retrying.
+    * @param retriesLeft
+    *   Number of retries
+    * @param filter
+    *   A filter to check if the cause of failure should prevent retrying.
     */
   case class Immediate(retriesLeft: Int, filter: Throwable => Boolean = always) extends RetryPolicy {
     override def canRetry(reason: Throwable) =
@@ -67,10 +72,14 @@ object Retry {
   /**
     * Provides an exponential backoff algorithm for retrying.
     *
-    * @param retriesLeft Number of retries
-    * @param delay Delay after failure before trying again. Grows on each retry to `prevDelay * exp`
-    * @param exp Exponential growth factor for delay. Default is 2.0 leading to delay doubling on every retry.
-    * @param filter A filter to check if the cause of failure should prevent retrying.
+    * @param retriesLeft
+    *   Number of retries
+    * @param delay
+    *   Delay after failure before trying again. Grows on each retry to `prevDelay * exp`
+    * @param exp
+    *   Exponential growth factor for delay. Default is 2.0 leading to delay doubling on every retry.
+    * @param filter
+    *   A filter to check if the cause of failure should prevent retrying.
     */
   case class Backoff(
       retriesLeft: Int,

--- a/diode-core/shared/src/test/scala/diode/CircuitTests.scala
+++ b/diode-core/shared/src/test/scala/diode/CircuitTests.scala
@@ -357,7 +357,8 @@ object CircuitTests extends TestSuite {
           override def process(dispatcher: Dispatcher,
                                action: Any,
                                next: Any => ActionResult[Model],
-                               currentModel: Model) = {
+                               currentModel: Model
+          ) = {
             next(action match {
               case s: String =>
                 SetS(s)
@@ -378,7 +379,8 @@ object CircuitTests extends TestSuite {
           override def process(dispatcher: Dispatcher,
                                action: Any,
                                next: Any => ActionResult[Model],
-                               currentModel: Model) = {
+                               currentModel: Model
+          ) = {
             action match {
               case SetS(_) =>
                 ActionResult.NoChange
@@ -397,7 +399,8 @@ object CircuitTests extends TestSuite {
           override def process(dispatcher: Dispatcher,
                                action: Any,
                                next: Any => ActionResult[Model],
-                               currentModel: Model) = {
+                               currentModel: Model
+          ) = {
             next(action) match {
               case m: ModelUpdated[Model @unchecked] =>
                 log += m.newModel.s
@@ -418,7 +421,8 @@ object CircuitTests extends TestSuite {
           override def process(dispatcher: Dispatcher,
                                action: Any,
                                next: Any => ActionResult[Model],
-                               currentModel: Model) = {
+                               currentModel: Model
+          ) = {
             action match {
               case Delay(a) =>
                 pending.enqueue((a, dispatcher))

--- a/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
+++ b/diode-data/shared/src/main/scala/diode/data/AsyncAction.scala
@@ -7,8 +7,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Base trait for asynchronous actions. Provides support for handling of multi-state actions. Implementation classes
-  * must implement `result`, `next` and `state` functions. If you are using `Pot`, consider using `PotAction` instead.
+  * Base trait for asynchronous actions. Provides support for handling of multi-state actions. Implementation classes must
+  * implement `result`, `next` and `state` functions. If you are using `Pot`, consider using `PotAction` instead.
   *
   * Example:
   * {{{
@@ -19,8 +19,10 @@ import scala.util.{Failure, Success, Try}
   * }
   * }}}
   *
-  * @tparam A Type of action result
-  * @tparam P Type of the actual action class
+  * @tparam A
+  *   Type of action result
+  * @tparam P
+  *   Type of the actual action class
   */
 trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   implicit object PActionType extends ActionType[P]
@@ -32,9 +34,12 @@ trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   /**
     * Moves the action to the next state.
     *
-    * @param newState New state for the action
-    * @param newValue New value for the action
-    * @return A new instance of this action with updated state and value
+    * @param newState
+    *   New state for the action
+    * @param newValue
+    *   New value for the action
+    * @return
+    *   A new instance of this action with updated state and value
     */
   def next(newState: PotState, newValue: Try[A]): P
 
@@ -49,16 +54,21 @@ trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
     pf(state)
 
   /**
-    * Handles the action using an external handler function. The function is provided with instance of this
-    * `AsyncAction`, the `ActionHandler` this action currently resides in and the provided update `Effect`.
+    * Handles the action using an external handler function. The function is provided with instance of this `AsyncAction`,
+    * the `ActionHandler` this action currently resides in and the provided update `Effect`.
     *
-    * @param handler The current action handler instance.
-    * @param effect  Effect that performs the requested async operation.
-    * @param f       External handler function
-    * @return An action result
+    * @param handler
+    *   The current action handler instance.
+    * @param effect
+    *   Effect that performs the requested async operation.
+    * @param f
+    *   External handler function
+    * @return
+    *   An action result
     */
   def handleWith[M, T](handler: ActionHandler[M, T], effect: Effect)(
-      f: (this.type, ActionHandler[M, T], Effect) => ActionResult[M]): ActionResult[M] =
+      f: (this.type, ActionHandler[M, T], Effect) => ActionResult[M]
+  ): ActionResult[M] =
     f(this, handler, effect)
 
   /**
@@ -72,7 +82,8 @@ trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   /**
     * Moves this action to ready state with a result value.
     *
-    * @param a Result for the action.
+    * @param a
+    *   Result for the action.
     * @return
     */
   def ready(a: A) =
@@ -81,7 +92,8 @@ trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   /**
     * Moves this action to a failed state with the provided exception.
     *
-    * @param ex Reason for the failure.
+    * @param ex
+    *   Reason for the failure.
     * @return
     */
   def failed(ex: Throwable) =
@@ -90,22 +102,29 @@ trait AsyncAction[A, P <: AsyncAction[A, P]] extends Action {
   /**
     * Wraps a by-name future result into an effect using success and failure transformations.
     *
-    * @param f       Future to wrap, passes using by-name (lazy evaluation)
-    * @param success Transformation function for success case
-    * @param failure Transformation function for failure case
-    * @return An `Effect` for running the provided `Future`
+    * @param f
+    *   Future to wrap, passes using by-name (lazy evaluation)
+    * @param success
+    *   Transformation function for success case
+    * @param failure
+    *   Transformation function for failure case
+    * @return
+    *   An `Effect` for running the provided `Future`
     */
-  def effect[B](f: => Future[B])(success: B => A, failure: Throwable => Throwable = identity)(
-      implicit ec: ExecutionContext) =
+  def effect[B](f: => Future[B])(success: B => A, failure: Throwable => Throwable = identity)(implicit
+      ec: ExecutionContext
+  ) =
     Effect(f.map(x => ready(success(x))).recover { case e: Throwable => failed(failure(e)) })
 }
 
 /**
-  * A retriable version of `AsyncAction`. Implementation must define a `retryPolicy`, which is also passed on
-  * in the `next` method.
+  * A retriable version of `AsyncAction`. Implementation must define a `retryPolicy`, which is also passed on in the `next`
+  * method.
   *
-  * @tparam A Type of action result
-  * @tparam P Type of the actual action class
+  * @tparam A
+  *   Type of action result
+  * @tparam P
+  *   Type of the actual action class
   */
 trait AsyncActionRetriable[A, P <: AsyncActionRetriable[A, P]] extends AsyncAction[A, P] {
   def next(newState: PotState, newValue: Try[A], newRetryPolicy: RetryPolicy): P
@@ -116,26 +135,32 @@ trait AsyncActionRetriable[A, P <: AsyncActionRetriable[A, P]] extends AsyncActi
     next(newState, newValue, retryPolicy)
 
   /**
-    * Handles the action using an external handler function. The function is provided with instance of this
-    * `AsyncAction`, the `ActionHandler` this action currently resides in and the provided update `Effect`
-    * creator function. The reason why retry policy is provided to the effect creator is that in case of failure, the
-    * updated retry policy can be passed on to the next effect instantiation.
+    * Handles the action using an external handler function. The function is provided with instance of this `AsyncAction`,
+    * the `ActionHandler` this action currently resides in and the provided update `Effect` creator function. The reason why
+    * retry policy is provided to the effect creator is that in case of failure, the updated retry policy can be passed on to
+    * the next effect instantiation.
     *
-    * @param handler     The current action handler instance.
-    * @param effectRetry Function taking current `RetryPolicy` and returning an effect that performs the requested
-    *                    async operation.
-    * @param f           External handler function
-    * @return An action result
+    * @param handler
+    *   The current action handler instance.
+    * @param effectRetry
+    *   Function taking current `RetryPolicy` and returning an effect that performs the requested async operation.
+    * @param f
+    *   External handler function
+    * @return
+    *   An action result
     */
   def handleWith[M, T](handler: ActionHandler[M, T], effectRetry: RetryPolicy => Effect)(
-      f: (this.type, ActionHandler[M, T], RetryPolicy => Effect) => ActionResult[M]): ActionResult[M] =
+      f: (this.type, ActionHandler[M, T], RetryPolicy => Effect) => ActionResult[M]
+  ): ActionResult[M] =
     f(this, handler, effectRetry)
 
   /**
     * Moves this action to a failed state with the provided exception.
     *
-    * @param ex Exception describing the reason for failure
-    * @param nextRetryPolicy Updated retry policy
+    * @param ex
+    *   Exception describing the reason for failure
+    * @param nextRetryPolicy
+    *   Updated retry policy
     * @return
     */
   def failed(ex: Throwable, nextRetryPolicy: RetryPolicy = retryPolicy) =
@@ -144,13 +169,18 @@ trait AsyncActionRetriable[A, P <: AsyncActionRetriable[A, P]] extends AsyncActi
   /**
     * Wraps a by-name future result into an effect creator function, using success and failure transformations.
     *
-    * @param f       Future to wrap, passes using by-name (lazy evaluation)
-    * @param success Transformation function for success case
-    * @param failure Transformation function for failure case
-    * @return An `Effect` for running the provided `Future`
+    * @param f
+    *   Future to wrap, passes using by-name (lazy evaluation)
+    * @param success
+    *   Transformation function for success case
+    * @param failure
+    *   Transformation function for failure case
+    * @return
+    *   An `Effect` for running the provided `Future`
     */
-  def effectWithRetry[B](f: => Future[B])(success: B => A, failure: Throwable => Throwable = identity)(
-      implicit ec: ExecutionContext) =
+  def effectWithRetry[B](
+      f: => Future[B]
+  )(success: B => A, failure: Throwable => Throwable = identity)(implicit ec: ExecutionContext) =
     (nextRetryPolicy: RetryPolicy) =>
       Effect(f.map(x => ready(success(x))).recover { case e: Throwable => failed(failure(e), nextRetryPolicy) })
 }
@@ -164,79 +194,81 @@ object AsyncAction {
   /**
     * An async action handler for executing updates to a `PotMap`.
     *
-    * @param keys Set of keys to update.
-    * @return The handler function
+    * @param keys
+    *   Set of keys to update.
+    * @return
+    *   The handler function
     */
   def mapHandler[K, V, A <: Iterable[(K, Pot[V])], M, P <: AsyncAction[A, P]](keys: Set[K]) = {
     require(keys.nonEmpty, "AsyncAction:mapHandler - The set of keys to update can't be empty")
-    (action: AsyncAction[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: Effect) =>
-      {
-        import PotState._
-        import handler._
-        // updates/adds only those values whose key is in the `keys` set
-        def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotMap[K, V] = {
-          // update existing values
-          value.map { (k, v) =>
-            if (keys.contains(k))
-              f(v)
-            else
-              v
-          } ++ (keys -- value.keySet).map(k => k -> default) // add new ones
-        }
-        action.state match {
-          case PotEmpty =>
-            updated(updateInCollection(_.pending(), Pending()), updateEffect)
-          case PotPending =>
-            noChange
-          case PotUnavailable =>
-            noChange
-          case PotReady =>
-            updated(value.updated(action.result.get))
-          case PotFailed =>
-            val ex = action.result.failed.get
-            updated(updateInCollection(_.fail(ex), Failed(ex)))
-        }
+    (action: AsyncAction[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: Effect) => {
+      import PotState._
+      import handler._
+      // updates/adds only those values whose key is in the `keys` set
+      def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotMap[K, V] = {
+        // update existing values
+        value.map { (k, v) =>
+          if (keys.contains(k))
+            f(v)
+          else
+            v
+        } ++ (keys -- value.keySet).map(k => k -> default) // add new ones
       }
+      action.state match {
+        case PotEmpty =>
+          updated(updateInCollection(_.pending(), Pending()), updateEffect)
+        case PotPending =>
+          noChange
+        case PotUnavailable =>
+          noChange
+        case PotReady =>
+          updated(value.updated(action.result.get))
+        case PotFailed =>
+          val ex = action.result.failed.get
+          updated(updateInCollection(_.fail(ex), Failed(ex)))
+      }
+    }
   }
 
   /**
     * An async action handler for executing updates to a `PotVector`.
     *
-    * @param indices Set of indices to update
-    * @return The handler function
+    * @param indices
+    *   Set of indices to update
+    * @return
+    *   The handler function
     */
   def vectorHandler[V, A <: Iterable[(Int, Pot[V])], M, P <: AsyncAction[A, P]](indices: Set[Int]) = {
     require(indices.nonEmpty, "AsyncAction:vectorHandler - The set of indices to update can't be empty")
-    (action: AsyncAction[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: Effect) =>
-      {
-        import PotState._
-        import handler._
-        // updates/adds only those values whose index is in the `indices` set
-        def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotVector[V] = {
-          // update existing values
-          value
-            .map { (k, v) =>
-              if (indices.contains(k))
-                f(v)
-              else
-                v
-            }
-            .updated(indices.filterNot(value.contains).map(i => i -> default)) // add new ones
-        }
-        action.state match {
-          case PotEmpty =>
-            updated(updateInCollection(_.pending(), Pending()), updateEffect)
-          case PotPending =>
-            noChange
-          case PotUnavailable =>
-            noChange
-          case PotReady =>
-            updated(value.updated(action.result.get))
-          case PotFailed =>
-            val ex = action.result.failed.get
-            updated(updateInCollection(_.fail(ex), Failed(ex)))
-        }
+    (action: AsyncAction[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: Effect) => {
+      import PotState._
+      import handler._
+      // updates/adds only those values whose index is in the `indices` set
+      def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotVector[V] = {
+        // update existing values
+        value
+          .map { (k, v) =>
+            if (indices.contains(k))
+              f(v)
+            else
+              v
+          }
+          .updated(indices.filterNot(value.contains).map(i => i -> default)) // add new ones
       }
+      action.state match {
+        case PotEmpty =>
+          updated(updateInCollection(_.pending(), Pending()), updateEffect)
+        case PotPending =>
+          noChange
+        case PotUnavailable =>
+          noChange
+        case PotReady =>
+          updated(value.updated(action.result.get))
+        case PotFailed =>
+          val ex = action.result.failed.get
+          updated(updateInCollection(_.fail(ex), Failed(ex)))
+      }
+    }
   }
 }
 
@@ -249,86 +281,88 @@ object AsyncActionRetriable {
   /**
     * A retriable async action handler for executing updates to a `PotMap`.
     *
-    * @param keys Set of keys to update.
-    * @return The handler function
+    * @param keys
+    *   Set of keys to update.
+    * @return
+    *   The handler function
     */
   def mapHandler[K, V, A <: Iterable[(K, Pot[V])], M, P <: AsyncActionRetriable[A, P]](keys: Set[K]) = {
     require(keys.nonEmpty, "AsyncActionRetriable:mapHandler - The set of keys to update can't be empty")
-    (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: RetryPolicy => Effect) =>
-      {
-        import PotState._
-        import handler._
-        // updates/adds only those values whose key is in the `keys` set
-        def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotMap[K, V] = {
-          // update existing values
-          value.map { (k, v) =>
-            if (keys.contains(k))
-              f(v)
-            else
-              v
-          } ++ (keys -- value.keySet).map(k => k -> default) // add new ones
-        }
-        action.state match {
-          case PotEmpty =>
-            updated(updateInCollection(_.pending(), Pending()), updateEffect(action.retryPolicy))
-          case PotPending =>
-            noChange
-          case PotUnavailable =>
-            noChange
-          case PotReady =>
-            updated(value.updated(action.result.get))
-          case PotFailed =>
-            action.retryPolicy.retry(action.result.failed.get, updateEffect) match {
-              case Right((_, retryEffect)) =>
-                updated(updateInCollection(_.pending(), Pending()), retryEffect)
-              case Left(ex) =>
-                updated(updateInCollection(_.fail(ex), Failed(ex)))
-            }
-        }
+    (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotMap[K, V]], updateEffect: RetryPolicy => Effect) => {
+      import PotState._
+      import handler._
+      // updates/adds only those values whose key is in the `keys` set
+      def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotMap[K, V] = {
+        // update existing values
+        value.map { (k, v) =>
+          if (keys.contains(k))
+            f(v)
+          else
+            v
+        } ++ (keys -- value.keySet).map(k => k -> default) // add new ones
       }
+      action.state match {
+        case PotEmpty =>
+          updated(updateInCollection(_.pending(), Pending()), updateEffect(action.retryPolicy))
+        case PotPending =>
+          noChange
+        case PotUnavailable =>
+          noChange
+        case PotReady =>
+          updated(value.updated(action.result.get))
+        case PotFailed =>
+          action.retryPolicy.retry(action.result.failed.get, updateEffect) match {
+            case Right((_, retryEffect)) =>
+              updated(updateInCollection(_.pending(), Pending()), retryEffect)
+            case Left(ex) =>
+              updated(updateInCollection(_.fail(ex), Failed(ex)))
+          }
+      }
+    }
   }
 
   /**
     * A retriable async action handler for executing updates to a `PotVector`.
     *
-    * @param indices Set of indices to update
-    * @return The handler function
+    * @param indices
+    *   Set of indices to update
+    * @return
+    *   The handler function
     */
   def vectorHandler[V, A <: Iterable[(Int, Pot[V])], M, P <: AsyncActionRetriable[A, P]](indices: Set[Int]) = {
     require(indices.nonEmpty, "AsyncActionRetriable:vectorHandler - The set of indices to update can't be empty")
-    (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: RetryPolicy => Effect) =>
-      {
-        import PotState._
-        import handler._
-        // updates/adds only those values whose index is in the `indices` set
-        def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotVector[V] = {
-          // update existing values
-          value
-            .map { (k, v) =>
-              if (indices.contains(k))
-                f(v)
-              else
-                v
-            }
-            .updated(indices.filterNot(value.contains).map(i => i -> default)) // add new ones
-        }
-        action.state match {
-          case PotEmpty =>
-            updated(updateInCollection(_.pending(), Pending()), updateEffect(action.retryPolicy))
-          case PotPending =>
-            noChange
-          case PotUnavailable =>
-            noChange
-          case PotReady =>
-            updated(value.updated(action.result.get))
-          case PotFailed =>
-            action.retryPolicy.retry(action.result.failed.get, updateEffect) match {
-              case Right((_, retryEffect)) =>
-                updated(updateInCollection(_.pending(), Pending()), retryEffect)
-              case Left(ex) =>
-                updated(updateInCollection(_.fail(ex), Failed(ex)))
-            }
-        }
+    (action: AsyncActionRetriable[A, P], handler: ActionHandler[M, PotVector[V]], updateEffect: RetryPolicy => Effect) => {
+      import PotState._
+      import handler._
+      // updates/adds only those values whose index is in the `indices` set
+      def updateInCollection(f: Pot[V] => Pot[V], default: Pot[V]): PotVector[V] = {
+        // update existing values
+        value
+          .map { (k, v) =>
+            if (indices.contains(k))
+              f(v)
+            else
+              v
+          }
+          .updated(indices.filterNot(value.contains).map(i => i -> default)) // add new ones
       }
+      action.state match {
+        case PotEmpty =>
+          updated(updateInCollection(_.pending(), Pending()), updateEffect(action.retryPolicy))
+        case PotPending =>
+          noChange
+        case PotUnavailable =>
+          noChange
+        case PotReady =>
+          updated(value.updated(action.result.get))
+        case PotFailed =>
+          action.retryPolicy.retry(action.result.failed.get, updateEffect) match {
+            case Right((_, retryEffect)) =>
+              updated(updateInCollection(_.pending(), Pending()), retryEffect)
+            case Left(ex) =>
+              updated(updateInCollection(_.fail(ex), Failed(ex)))
+          }
+      }
+    }
   }
 }

--- a/diode-data/shared/src/main/scala/diode/data/Pot.scala
+++ b/diode-data/shared/src/main/scala/diode/data/Pot.scala
@@ -26,9 +26,12 @@ object PotState {
 /**
   * Represents a potential value that may be in different states.
   *
-  * @define pot   [[Pot]]
-  * @define ready [[Ready]]
-  * @define empty [[Empty]]
+  * @define pot
+  *   [[Pot]]
+  * @define ready
+  *   [[Ready]]
+  * @define empty
+  *   [[Empty]]
   */
 sealed abstract class Pot[+A] extends Product with Serializable { self =>
 
@@ -45,24 +48,29 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
   def unavailable() = Unavailable
   def state: PotState
 
-  /** Returns false if the pot is Empty, true otherwise.
+  /**
+    * Returns false if the pot is Empty, true otherwise.
     *
-    * @note Implemented here to avoid the implicit conversion to Iterable.
+    * @note
+    *   Implemented here to avoid the implicit conversion to Iterable.
     */
   final def nonEmpty = !isEmpty
 
   @inline final def getOrElse[B >: A](default: => B): B =
     if (isEmpty) default else this.get
 
-  /** Returns a Ready containing the result of applying $f to this Pot's
-    * value if this Pot is nonempty.
-    * Otherwise return current Pot.
+  /**
+    * Returns a Ready containing the result of applying $f to this Pot's value if this Pot is nonempty. Otherwise return
+    * current Pot.
     *
-    * @note This is similar to `flatMap` except here,
-    *       $f does not need to wrap its result in a pot.
-    * @param  f the function to apply
-    * @see flatMap
-    * @see foreach
+    * @note
+    *   This is similar to `flatMap` except here, $f does not need to wrap its result in a pot.
+    * @param f
+    *   the function to apply
+    * @see
+    *   flatMap
+    * @see
+    *   foreach
     */
   @noinline final def map[B](f: A => B): Pot[B] = this match {
     case Empty              => Empty
@@ -74,26 +82,30 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
     case Unavailable        => Unavailable
   }
 
-  /** Returns the result of applying $f to this Pot's
-    * value if the Pot is nonempty.  Otherwise, evaluates
-    * expression `ifEmpty`.
+  /**
+    * Returns the result of applying $f to this Pot's value if the Pot is nonempty. Otherwise, evaluates expression
+    * `ifEmpty`.
     *
-    * @note This is equivalent to `Pot map f getOrElse ifEmpty`.
-    * @param  ifEmpty the expression to evaluate if empty.
-    * @param  f       the function to apply if nonempty.
+    * @note
+    *   This is equivalent to `Pot map f getOrElse ifEmpty`.
+    * @param ifEmpty
+    *   the expression to evaluate if empty.
+    * @param f
+    *   the function to apply if nonempty.
     */
   @inline final def fold[B](ifEmpty: => B)(f: A => B): B =
     if (isEmpty) ifEmpty else f(this.get)
 
-  /** Returns the result of applying $f to this Pot's value if
-    * this Pot is nonempty.
-    * Returns current Pot if this Pot does not have a value.
-    * Slightly different from `map` in that $f is expected to
-    * return a pot (which could be Empty).
+  /**
+    * Returns the result of applying $f to this Pot's value if this Pot is nonempty. Returns current Pot if this Pot does not
+    * have a value. Slightly different from `map` in that $f is expected to return a pot (which could be Empty).
     *
-    * @param  f the function to apply
-    * @see map
-    * @see foreach
+    * @param f
+    *   the function to apply
+    * @see
+    *   map
+    * @see
+    *   foreach
     */
   @noinline def flatMap[B](f: A => Pot[B]): Pot[B] = map(f).flatten
 
@@ -118,30 +130,34 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
     case Unavailable => Unavailable
   }
 
-  /** Returns this Pot if it is nonempty '''and''' applying the predicate $p to
-    * this Pot's value returns true. Otherwise, return Empty.
+  /**
+    * Returns this Pot if it is nonempty '''and''' applying the predicate $p to this Pot's value returns true. Otherwise,
+    * return Empty.
     *
-    * @param  p the predicate used for testing.
+    * @param p
+    *   the predicate used for testing.
     */
   @inline final def filter(p: A => Boolean): Pot[A] =
     if (isEmpty || p(this.get)) this else Empty
 
-  /** Returns this Pot if it is nonempty '''and''' applying the predicate $p to
-    * this Pot's value returns false. Otherwise, return Empty.
+  /**
+    * Returns this Pot if it is nonempty '''and''' applying the predicate $p to this Pot's value returns false. Otherwise,
+    * return Empty.
     *
-    * @param  p the predicate used for testing.
+    * @param p
+    *   the predicate used for testing.
     */
   @inline final def filterNot(p: A => Boolean): Pot[A] =
     if (isEmpty || !p(this.get)) this else Empty
 
-  /** Necessary to keep Pot from being implicitly converted to
-    * [[scala.collection.Iterable]] in `for` comprehensions.
+  /**
+    * Necessary to keep Pot from being implicitly converted to [[scala.collection.Iterable]] in `for` comprehensions.
     */
   @inline final def withFilter(p: A => Boolean): WithFilter = new WithFilter(p)
 
-  /** We need a whole WithFilter class to honor the "doesn't create a new
-    * collection" contract even though it seems unlikely to matter much in a
-    * collection with max size 1.
+  /**
+    * We need a whole WithFilter class to honor the "doesn't create a new collection" contract even though it seems unlikely
+    * to matter much in a collection with max size 1.
     */
   class WithFilter(p: A => Boolean) {
     def map[B](f: A => B): Pot[B] = self filter p map f
@@ -153,58 +169,63 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
     def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
   }
 
-  /** Tests whether the pot contains a given value as an element.
+  /**
+    * Tests whether the pot contains a given value as an element.
     *
     * @example
     * {{{
-    *  // Returns true because Ready instance contains string "something" which equals "something".
-    *  Ready("something") contains "something"
+    *   // Returns true because Ready instance contains string "something" which equals "something".
+    *   Ready("something") contains "something"
     *
-    *  // Returns false because "something" != "anything".
-    *  Ready("something") contains "anything"
+    *   // Returns false because "something" != "anything".
+    *   Ready("something") contains "anything"
     *
-    *  // Returns false when method called on Empty.
-    *  Empty contains "anything"
+    *   // Returns false when method called on Empty.
+    *   Empty contains "anything"
     * }}}
-    * @param elem the element to test.
-    * @return `true` if the pot has an element that is equal (as
-    *         determined by `==`) to `elem`, `false` otherwise.
+    * @param elem
+    *   the element to test.
+    * @return
+    *   `true` if the pot has an element that is equal (as determined by `==`) to `elem`, `false` otherwise.
     */
   final def contains[A1 >: A](elem: A1): Boolean =
     !isEmpty && this.get == elem
 
-  /** Returns true if this pot is nonempty '''and''' the predicate
-    * $p returns true when applied to this Pot's value.
+  /**
+    * Returns true if this pot is nonempty '''and''' the predicate $p returns true when applied to this Pot's value.
     * Otherwise, returns false.
     *
-    * @param  p the predicate to test
+    * @param p
+    *   the predicate to test
     */
   @inline final def exists(p: A => Boolean): Boolean =
     !isEmpty && p(this.get)
 
-  /** Returns true if this pot is empty '''or''' the predicate
-    * $p returns true when applied to this Pot's value.
+  /**
+    * Returns true if this pot is empty '''or''' the predicate $p returns true when applied to this Pot's value.
     *
-    * @param  p the predicate to test
+    * @param p
+    *   the predicate to test
     */
   @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
 
-  /** Apply the given procedure $f to the pot's value,
-    * if it is nonempty. Otherwise, do nothing.
+  /**
+    * Apply the given procedure $f to the pot's value, if it is nonempty. Otherwise, do nothing.
     *
-    * @param  f the procedure to apply.
-    * @see map
-    * @see flatMap
+    * @param f
+    *   the procedure to apply.
+    * @see
+    *   map
+    * @see
+    *   flatMap
     */
   @inline final def foreach[U](f: A => U): Unit = {
     if (!isEmpty) f(this.get)
   }
 
-  /** Returns a Ready containing the result of
-    * applying `pf` to this Pot's contained
-    * value, '''if''' this pot is
-    * nonempty '''and''' `pf` is defined for that value.
-    * Returns Empty otherwise.
+  /**
+    * Returns a Ready containing the result of applying `pf` to this Pot's contained value, '''if''' this pot is nonempty
+    * '''and''' `pf` is defined for that value. Returns Empty otherwise.
     *
     * @example
     * {{{
@@ -217,37 +238,39 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
     * // Returns Empty because Empty is passed to the collect method.
     * Empty collect {case value => value}
     * }}}
-    * @param  pf the partial function.
-    * @return the result of applying `pf` to this Pot's
-    *         value (if possible), or Empty.
+    * @param pf
+    *   the partial function.
+    * @return
+    *   the result of applying `pf` to this Pot's value (if possible), or Empty.
     */
   @inline final def collect[B](pf: PartialFunction[A, B]): Pot[B] =
     if (!isEmpty) pf.lift(this.get).map(b => Ready(b)).getOrElse(Empty) else Empty
 
-  /** Returns this Pot if it is nonempty,
-    * otherwise return the result of evaluating `alternative`.
+  /**
+    * Returns this Pot if it is nonempty, otherwise return the result of evaluating `alternative`.
     *
-    * @param alternative the alternative expression.
+    * @param alternative
+    *   the alternative expression.
     */
   @inline final def orElse[B >: A](alternative: => Pot[B]): Pot[B] =
     if (isEmpty) alternative else this
 
   /**
-    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
-    * This is like `flatMap` for the exception.
+    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`. This is like
+    * `flatMap` for the exception.
     */
   def recoverWith[B >: A](f: PartialFunction[Throwable, Pot[B]]): Pot[B] = this
 
   /**
-    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
-    * This is like map for the exception.
+    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`. This is like map
+    * for the exception.
     */
   def recover[B >: A](f: PartialFunction[Throwable, B]): Pot[B] = this
 
   def exceptionOption = Option.empty[Throwable]
 
-  /** Returns a singleton iterator returning the Pot's value
-    * if it is nonempty, or an empty iterator if the pot is empty.
+  /**
+    * Returns a singleton iterator returning the Pot's value if it is nonempty, or an empty iterator if the pot is empty.
     */
   def iterator: Iterator[A] =
     if (isEmpty) collection.Iterator.empty else collection.Iterator.single(this.get)
@@ -271,30 +294,32 @@ sealed abstract class Pot[+A] extends Product with Serializable { self =>
       }
   }
 
-  /** Returns a singleton list containing the Pot's value
-    * if it is nonempty, or the empty list if the Pot is empty.
+  /**
+    * Returns a singleton list containing the Pot's value if it is nonempty, or the empty list if the Pot is empty.
     */
   def toList: List[A] =
     if (isEmpty) List() else new ::(this.get, Nil)
 
-  /** Returns a [[scala.util.Left]] containing the given
-    * argument `left` if this Pot is empty, or
-    * a [[scala.util.Right]] containing this Pot's value if
-    * this is nonempty.
+  /**
+    * Returns a [[scala.util.Left]] containing the given argument `left` if this Pot is empty, or a [[scala.util.Right]]
+    * containing this Pot's value if this is nonempty.
     *
-    * @param left the expression to evaluate and return if this is empty
-    * @see toLeft
+    * @param left
+    *   the expression to evaluate and return if this is empty
+    * @see
+    *   toLeft
     */
   @inline final def toRight[X](left: => X) =
     if (isEmpty) Left(left) else Right(this.get)
 
-  /** Returns a [[scala.util.Right]] containing the given
-    * argument `right` if this is empty, or
-    * a [[scala.util.Left]] containing this Pot's value
-    * if this Pot is nonempty.
+  /**
+    * Returns a [[scala.util.Right]] containing the given argument `right` if this is empty, or a [[scala.util.Left]]
+    * containing this Pot's value if this Pot is nonempty.
     *
-    * @param right the expression to evaluate and return if this is empty
-    * @see toRight
+    * @param right
+    *   the expression to evaluate and return if this is empty
+    * @see
+    *   toRight
     */
   @inline final def toLeft[X](right: => X) =
     if (isEmpty) Right(right) else Left(this.get)
@@ -304,12 +329,13 @@ object Pot {
 
   import scala.language.implicitConversions
 
-  /** An implicit conversion that converts an option to an iterable value
+  /**
+    * An implicit conversion that converts an option to an iterable value
     */
   implicit def pot2Iterable[A](pot: Pot[A]): Iterable[A] = pot.toList
 
-  /** A Pot factory which returns `Empty` in a manner consistent with
-    * the collections hierarchy.
+  /**
+    * A Pot factory which returns `Empty` in a manner consistent with the collections hierarchy.
     */
   def empty[A]: Pot[A] = Empty
 

--- a/diode-data/shared/src/main/scala/diode/data/PotCollection.scala
+++ b/diode-data/shared/src/main/scala/diode/data/PotCollection.scala
@@ -32,11 +32,13 @@ trait Fetch[K] {
 }
 
 /**
-  * Trait defining common functionality for all potential collections. All values inside the collection are
-  * wrapped in `Pot[V]`
+  * Trait defining common functionality for all potential collections. All values inside the collection are wrapped in
+  * `Pot[V]`
   *
-  * @tparam K Type of the key
-  * @tparam V Type of the potential value
+  * @tparam K
+  *   Type of the key
+  * @tparam V
+  *   Type of the potential value
   */
 trait PotCollection[K, V] {
   def updated(key: K, value: Pot[V]): PotCollection[K, V]

--- a/diode-data/shared/src/main/scala/diode/data/PotStream.scala
+++ b/diode-data/shared/src/main/scala/diode/data/PotStream.scala
@@ -8,7 +8,8 @@ final case class StreamValue[K, V](key: K,
                                    value: V,
                                    stream: PotStream[K, V],
                                    prevKey: Option[K] = None,
-                                   nextKey: Option[K] = None) {
+                                   nextKey: Option[K] = None
+) {
   def apply() = value
 
   def prev = stream.get(prevKey)
@@ -46,15 +47,18 @@ class PotStream[K, V](
                       next: Option[K],
                       head: (K, V),
                       tail: Seq[(K, V)],
-                      acc: List[StreamValue[K, V]]): List[StreamValue[K, V]] = {
+                      acc: List[StreamValue[K, V]]
+      ): List[StreamValue[K, V]] = {
         if (tail.isEmpty) {
           StreamValue(head._1, head._2, this, prev, next) :: acc
         } else {
-          buildStream(Some(head._1),
-                      tail.tail.headOption.map(_._1),
-                      tail.head,
-                      tail.tail,
-                      StreamValue(head._1, head._2, this, prev, next) :: acc)
+          buildStream(
+            Some(head._1),
+            tail.tail.headOption.map(_._1),
+            tail.head,
+            tail.tail,
+            StreamValue(head._1, head._2, this, prev, next) :: acc
+          )
         }
       }
 
@@ -80,15 +84,18 @@ class PotStream[K, V](
                       next: Option[K],
                       head: (K, V),
                       tail: Seq[(K, V)],
-                      acc: List[StreamValue[K, V]]): List[StreamValue[K, V]] = {
+                      acc: List[StreamValue[K, V]]
+      ): List[StreamValue[K, V]] = {
         if (tail.isEmpty) {
           StreamValue(head._1, head._2, this, prev, next) :: acc
         } else {
-          buildStream(tail.tail.headOption.map(_._1),
-                      Some(head._1),
-                      tail.head,
-                      tail.tail,
-                      StreamValue(head._1, head._2, this, prev, next) :: acc)
+          buildStream(
+            tail.tail.headOption.map(_._1),
+            Some(head._1),
+            tail.head,
+            tail.tail,
+            StreamValue(head._1, head._2, this, prev, next) :: acc
+          )
         }
       }
 

--- a/diode-data/shared/src/main/scala/diode/data/RefTo.scala
+++ b/diode-data/shared/src/main/scala/diode/data/RefTo.scala
@@ -5,8 +5,10 @@ import diode._
 /**
   * Provides a reference to a value elsewhere in the model.
   *
-  * @param target  Model reader for the referred value
-  * @param updated Function to create an update action for the value this reference points to
+  * @param target
+  *   Model reader for the referred value
+  * @param updated
+  *   Function to create an update action for the value this reference points to
   */
 class RefTo[V](val target: ModelRO[V], val updated: V => Action) {
   def apply() = target()
@@ -17,7 +19,8 @@ object RefTo {
   /**
     * Provides a read-only reference that always produces a `NoAction` when an update is requested.
     *
-    * @param target Model reader for the referred value
+    * @param target
+    *   Model reader for the referred value
     */
   @inline def apply[V](target: ModelRO[V]): RefTo[V] =
     new RefTo(target, (_: V) => NoAction)
@@ -28,24 +31,32 @@ object RefTo {
   /**
     * Builds a `RefTo` to a potential value inside a `PotCollection`
     *
-    * @param key        Identifies the potential value inside the collection
-    * @param collTarget Model reader for the `PotCollection` containing the potential value
-    * @param updated    Function to create an update action for the potential value this reference points to
+    * @param key
+    *   Identifies the potential value inside the collection
+    * @param collTarget
+    *   Model reader for the `PotCollection` containing the potential value
+    * @param updated
+    *   Function to create an update action for the potential value this reference points to
     */
   @inline
-  def apply[K, V, P](key: K, collTarget: ModelRO[P])(updated: (K, Pot[V]) => Action)(
-      implicit ev: P <:< PotCollection[K, V]): RefTo[Pot[V]] =
+  def apply[K, V, P](key: K, collTarget: ModelRO[P])(updated: (K, Pot[V]) => Action)(implicit
+      ev: P <:< PotCollection[K, V]
+  ): RefTo[Pot[V]] =
     new RefTo[Pot[V]](collTarget.zoom(_.get(key)), updated(key, _: Pot[V]))
 
   /**
     * Builds a `RefTo` to a value inside a `PotStream`
     *
-    * @param key          Identifies the value inside the stream
-    * @param streamTarget Model reader for the `PotStream` containing the value
-    * @param updated      Function to create an update action for the potential value this reference points to
+    * @param key
+    *   Identifies the value inside the stream
+    * @param streamTarget
+    *   Model reader for the `PotStream` containing the value
+    * @param updated
+    *   Function to create an update action for the potential value this reference points to
     */
   @inline
-  def stream[K, V, P](key: K, streamTarget: ModelRO[P])(updated: (K, V) => Action)(implicit ev: P <:< PotStream[K, V],
-                                                                                   feq: FastEq[_ >: V]): RefTo[V] =
+  def stream[K, V, P](key: K, streamTarget: ModelRO[P])(
+      updated: (K, V) => Action
+  )(implicit ev: P <:< PotStream[K, V], feq: FastEq[_ >: V]): RefTo[V] =
     new RefTo[V](streamTarget.zoom(_.apply(key)), updated(key, _: V))
 }

--- a/diode-data/shared/src/test/scala/diode/data/PotActionTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotActionTests.scala
@@ -22,8 +22,8 @@ object PotActionTests extends TestSuite {
   }
 
   case class TestCollAction(state: PotState = PotState.PotEmpty,
-                            result: Try[Set[(String, Pot[String])]] = Failure(new AsyncAction.PendingException))
-      extends AsyncAction[Set[(String, Pot[String])], TestCollAction] {
+                            result: Try[Set[(String, Pot[String])]] = Failure(new AsyncAction.PendingException)
+  ) extends AsyncAction[Set[(String, Pot[String])], TestCollAction] {
     override def next(newState: PotState, newResult: Try[Set[(String, Pot[String])]]) =
       TestCollAction(newState, newResult)
   }
@@ -97,8 +97,10 @@ object PotActionTests extends TestSuite {
       "EffectFail" - {
         val ta = TestAction()
         val eff =
-          ta.effect(Future { if (true) throw new Exception("Oh no!") else 42 })(_.toString,
-                                                                                ex => new Exception(ex.getMessage * 2))
+          ta.effect(Future { if (true) throw new Exception("Oh no!") else 42 })(
+            _.toString,
+            ex => new Exception(ex.getMessage * 2)
+          )
 
         eff.toFuture.map { action =>
           assert(action.potResult.exceptionOption.exists(_.getMessage == "Oh no!Oh no!"))

--- a/diode-data/shared/src/test/scala/diode/data/PotCollectionTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/PotCollectionTests.scala
@@ -210,7 +210,7 @@ object PotCollectionTests extends TestSuite {
             action.handleWith(this, updateEffect)(AsyncAction.mapHandler(action.keys))
         }
       }
-     */
+       */
     }
   }
 }

--- a/diode-data/shared/src/test/scala/diode/data/RefToTests.scala
+++ b/diode-data/shared/src/test/scala/diode/data/RefToTests.scala
@@ -29,11 +29,14 @@ object RefToTests extends TestSuite {
       val modelRW = new RootModelRW(root)
       val m = root.copy(
         employees =
-          Seq(Employee("CEO", RefTo("ceoID", modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value")))))
+          Seq(Employee("CEO", RefTo("ceoID", modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value"))))
+      )
       assert(m.employees.head.user().get.name == "Ms. CEO")
       assert(
         m.employees.head.user.updated(Ready(User("Ms. Kathy CEO"))) == RefAction(
-          "Update ceoID to Ready(User(Ms. Kathy CEO))"))
+          "Update ceoID to Ready(User(Ms. Kathy CEO))"
+        )
+      )
     }
     "refToVector" - {
       val fetcher = new TestFetcher[Int]
@@ -42,10 +45,12 @@ object RefToTests extends TestSuite {
       val m =
         root.copy(
           employees =
-            Seq(Employee("CEO", RefTo(0, modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value")))))
+            Seq(Employee("CEO", RefTo(0, modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value"))))
+        )
       assert(m.employees.head.user().get.name == "Ms. CEO")
       assert(
-        m.employees.head.user.updated(Ready(User("Ms. Kathy CEO"))) == RefAction("Update 0 to Ready(User(Ms. Kathy CEO))"))
+        m.employees.head.user.updated(Ready(User("Ms. Kathy CEO"))) == RefAction("Update 0 to Ready(User(Ms. Kathy CEO))")
+      )
     }
     "refToStream" - {
       val fetcher = new TestFetcher[String]
@@ -53,11 +58,15 @@ object RefToTests extends TestSuite {
       val modelRW = new RootModelRW(root)
       val m = root.copy(
         employees = Seq(
-          Employee("CEO", RefTo.stream("ceoID", modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value")))))
+          Employee("CEO", RefTo.stream("ceoID", modelRW.zoom(_.users))((id, value) => RefAction(s"Update $id to $value")))
+        )
+      )
       assert(m.employees.head.user().get.name == "Ms. CEO")
       assert(
         m.employees.head.user.updated(Ready(User("Ms. Kathy CEO"))) == RefAction(
-          "Update ceoID to Ready(User(Ms. Kathy CEO))"))
+          "Update ceoID to Ready(User(Ms. Kathy CEO))"
+        )
+      )
     }
   }
 }

--- a/diode-devtools/shared/src/main/scala/diode/dev/PersistState.scala
+++ b/diode-devtools/shared/src/main/scala/diode/dev/PersistState.scala
@@ -6,8 +6,8 @@ import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
-  * Provides an action processor for saving and loading application state.
-  * Needs to be extended with an actual implementation for pickling and save/load.
+  * Provides an action processor for saving and loading application state. Needs to be extended with an actual implementation
+  * for pickling and save/load.
   */
 abstract class PersistState[M <: AnyRef, P] extends ActionProcessor[M] {
   import PersistState._

--- a/diode-react/src/main/scala/diode/react/ReactConnector.scala
+++ b/diode-react/src/main/scala/diode/react/ReactConnector.scala
@@ -7,8 +7,7 @@ import japgolly.scalajs.react.vdom.VdomElement
 import scala.scalajs.js
 
 /**
-  * Wraps a model reader, dispatcher and React connector to be passed to React components
-  * in props.
+  * Wraps a model reader, dispatcher and React connector to be passed to React components in props.
   */
 case class ModelProxy[S](modelReader: ModelRO[S], theDispatch: Any => Unit, connector: ReactConnector[_ <: AnyRef]) {
   def value = modelReader()
@@ -42,21 +41,28 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
   /**
     * Wraps a React component by providing it an instance of ModelProxy for easy access to the model and dispatcher.
     *
-    * @param zoomFunc Function to retrieve relevant piece from the model
-    * @param compB    Function that creates the wrapped component
-    * @return The component returned by `compB`
+    * @param zoomFunc
+    *   Function to retrieve relevant piece from the model
+    * @param compB
+    *   Function that creates the wrapped component
+    * @return
+    *   The component returned by `compB`
     */
-  def wrap[S <: AnyRef, C](zoomFunc: M => S)(compB: ModelProxy[S] => C)(implicit ev: C => VdomElement,
-                                                                        feq: FastEq[_ >: S]): C = {
+  def wrap[S <: AnyRef, C](
+      zoomFunc: M => S
+  )(compB: ModelProxy[S] => C)(implicit ev: C => VdomElement, feq: FastEq[_ >: S]): C = {
     wrap(circuit.zoom(zoomFunc))(compB)
   }
 
   /**
     * Wraps a React component by providing it an instance of ModelProxy for easy access to the model and dispatcher.
     *
-    * @param modelReader A reader that returns the piece of model we are interested in
-    * @param compB       Function that creates the wrapped component
-    * @return The component returned by `compB`
+    * @param modelReader
+    *   A reader that returns the piece of model we are interested in
+    * @param compB
+    *   Function that creates the wrapped component
+    * @return
+    *   The component returned by `compB`
     */
   def wrap[S <: AnyRef, C](modelReader: ModelRO[S])(compB: ModelProxy[S] => C)(implicit ev: C => VdomElement): C = {
     implicit object aType extends ActionType[Any]
@@ -65,35 +71,43 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
   }
 
   /**
-    * Connects a React component into the Circuit by wrapping it in another component that listens to
-    * relevant state changes and updates the wrapped component as needed.
+    * Connects a React component into the Circuit by wrapping it in another component that listens to relevant state changes
+    * and updates the wrapped component as needed.
     *
-    * @param zoomFunc Function to retrieve relevant piece from the model
-    * @param key      Specifies a unique React key for this component.
-    * @return A ReactConnectProxy
+    * @param zoomFunc
+    *   Function to retrieve relevant piece from the model
+    * @param key
+    *   Specifies a unique React key for this component.
+    * @return
+    *   A ReactConnectProxy
     */
   def connect[S <: AnyRef](zoomFunc: M => S, key: js.Any)(implicit feq: FastEq[_ >: S]): ReactConnectProxy[S] = {
     connect(circuit.zoom(zoomFunc), key)
   }
 
   /**
-    * Connects a React component into the Circuit by wrapping it in another component that listens to
-    * relevant state changes and updates the wrapped component as needed.
+    * Connects a React component into the Circuit by wrapping it in another component that listens to relevant state changes
+    * and updates the wrapped component as needed.
     *
-    * @param zoomFunc Function to retrieve relevant piece from the model
-    * @return A ReactConnectProxy
+    * @param zoomFunc
+    *   Function to retrieve relevant piece from the model
+    * @return
+    *   A ReactConnectProxy
     */
   def connect[S <: AnyRef](zoomFunc: M => S)(implicit feq: FastEq[_ >: S]): ReactConnectProxy[S] = {
     connect(circuit.zoom(zoomFunc))
   }
 
   /**
-    * Connects a React component into the Circuit by wrapping it in another component that listens to
-    * relevant state changes and updates the wrapped component as needed.
+    * Connects a React component into the Circuit by wrapping it in another component that listens to relevant state changes
+    * and updates the wrapped component as needed.
     *
-    * @param modelReader A reader that returns the piece of model we are interested in
-    * @param key         Optional parameter specifying a unique React key for this component.
-    * @return A ReactConnectProxy
+    * @param modelReader
+    *   A reader that returns the piece of model we are interested in
+    * @param key
+    *   Optional parameter specifying a unique React key for this component.
+    * @return
+    *   A ReactConnectProxy
     */
   def connect[S <: AnyRef](modelReader: ModelRO[S], key: js.UndefOr[js.Any] = js.undefined): ReactConnectProxy[S] = {
 

--- a/diode-react/src/main/scala/diode/react/ReactPot.scala
+++ b/diode-react/src/main/scala/diode/react/ReactPot.scala
@@ -11,7 +11,8 @@ object ReactPot {
     /**
       * Render non-empty (ready or stale) content
       *
-      * @param f Transforms Pot value into a VdomNode
+      * @param f
+      *   Transforms Pot value into a VdomNode
       * @return
       */
     def render(f: A => VdomNode): VdomNode =
@@ -20,7 +21,8 @@ object ReactPot {
     /**
       * Render content in Ready state, not including stale states
       *
-      * @param f Transforms Pot value into a VdomNode
+      * @param f
+      *   Transforms Pot value into a VdomNode
       * @return
       */
     def renderReady(f: A => VdomNode): VdomNode =
@@ -29,7 +31,8 @@ object ReactPot {
     /**
       * Render when Pot is pending
       *
-      * @param f Transforms duration time into a VdomNode
+      * @param f
+      *   Transforms duration time into a VdomNode
       * @return
       */
     def renderPending(f: Int => VdomNode): VdomNode =
@@ -38,8 +41,10 @@ object ReactPot {
     /**
       * Render when Pot is pending with a filter on duration
       *
-      * @param b Filter based on duration value
-      * @param f Transforms duration time into a VdomNode
+      * @param b
+      *   Filter based on duration value
+      * @param f
+      *   Transforms duration time into a VdomNode
       * @return
       */
     def renderPending(b: Int => Boolean, f: Int => VdomNode): VdomNode = {
@@ -52,7 +57,8 @@ object ReactPot {
     /**
       * Render when Pot has failed
       *
-      * @param f Transforms an exception into a VdomNode
+      * @param f
+      *   Transforms an exception into a VdomNode
       * @return
       */
     def renderFailed(f: Throwable => VdomNode): VdomNode =
@@ -61,7 +67,8 @@ object ReactPot {
     /**
       * Render stale content (`PendingStale` or `FailedStale`)
       *
-      * @param f Transforms Pot value into a VdomNode
+      * @param f
+      *   Transforms Pot value into a VdomNode
       * @return
       */
     def renderStale(f: A => VdomNode): VdomNode =
@@ -70,7 +77,8 @@ object ReactPot {
     /**
       * Render when Pot is empty
       *
-      * @param f Returns a VdomNode
+      * @param f
+      *   Returns a VdomNode
       * @return
       */
     def renderEmpty(f: => VdomNode): VdomNode =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 


### PR DESCRIPTION
This is in preparation for Scala 3 support (#177) - scalafmt must be updated. I tried to configure it to reduce the diff size but unfortunately still ended up with a pretty big diff, mostly due to docstrings.

I have Scala 3 support change ready but I thought I would submit this update as a separate PR due to the diff size.