### PR TITLE
Update scalajs-dom to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val diodeDevtools = crossProject(JSPlatform, JVMPlatform)
     name := "diode-devtools"
   )
   .jsSettings(
-    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "1.1.0"),
+    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "1.2.0"),
     scalacOptions ++= sourceMapSetting.value
   )
   .dependsOn(diodeCore)

--- a/diode-devtools/js/src/main/scala/diode/dev/PersistStateIDB.scala
+++ b/diode-devtools/js/src/main/scala/diode/dev/PersistStateIDB.scala
@@ -13,26 +13,24 @@ class PersistStateIDB[M <: AnyRef, P <: js.Any](pickleF: M => P, unpickleF: P =>
   // Opens (and creates) a database for snapshots
   // Contains the DB in a future, for easy async access
   private lazy val dbF = {
-    if (js.isUndefined(dom.window.indexedDB)) {
-      Future.failed(new Exception("IndexedDB is not supported"))
-    } else {
-      val req = dom.window.indexedDB.open("DiodePersistence")
-      val p   = Promise[IDBDatabase]()
-      req.onsuccess = (_: Event) => {
-        println("Open onsuccess")
-        p.success(req.result.asInstanceOf[IDBDatabase])
+    dom.window.indexedDB
+      .map(Future.successful)
+      .getOrElse(Future.failed(new Exception("IndexedDB is not supported")))
+      .flatMap { indexedDb =>
+        val req = indexedDb.open("DiodePersistence")
+        val p   = Promise[IDBDatabase]()
+        req.onsuccess = (_: Event) => {
+          p.success(req.result.asInstanceOf[IDBDatabase])
+        }
+        req.onupgradeneeded = (_: Event) => {
+          val db = req.result.asInstanceOf[IDBDatabase]
+          db.createObjectStore(storeName)
+        }
+        req.onerror = (_: Event) => {
+          p.failure(new Exception(s"IDB error ${req.error.name}"))
+        }
+        p.future
       }
-      req.onupgradeneeded = (_: Event) => {
-        println("Open onupgrade")
-        val db = req.result.asInstanceOf[IDBDatabase]
-        db.createObjectStore(storeName)
-      }
-      req.onerror = (_: Event) => {
-        println(s"Open onerror ${req.error.name}")
-        p.failure(new Exception(s"IDB error ${req.error.name}"))
-      }
-      p.future
-    }
   }
 
   private def withStore[A](f: IDBObjectStore => Future[A]) = {
@@ -52,11 +50,9 @@ class PersistStateIDB[M <: AnyRef, P <: js.Any](pickleF: M => P, unpickleF: P =>
       val p   = Promise[String]()
       val req = store.put(pickled, id)
       req.onsuccess = (_: Event) => {
-        println("Save onsuccess")
         p.success(req.result.asInstanceOf[String])
       }
       req.onerror = (_: Event) => {
-        println(s"Save onerror ${req.error.name}")
         p.failure(new Exception(s"IDB error ${req.error.name}"))
       }
       p.future
@@ -68,11 +64,9 @@ class PersistStateIDB[M <: AnyRef, P <: js.Any](pickleF: M => P, unpickleF: P =>
       val p   = Promise[P]()
       val req = store.get(id)
       req.onsuccess = (_: Event) => {
-        println("Load onsuccess")
         p.success(req.result.asInstanceOf[P])
       }
       req.onerror = (_: Event) => {
-        println(s"Load onerror ${req.error.name}")
         p.failure(new Exception(s"IDB error ${req.error.name}"))
       }
       p.future


### PR DESCRIPTION
`dom.window.indexedDB` is now wrapped in `js.UndefOr` which required a code change. I don't think that upgrade to 1.2.0 requires a major version bump of diode.