### PR TITLE
Updated diode-react to scalajs-react 2.0.0-RC3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## 1.2.0-RC1
+- Update diode-react to scalajs-react 2.0.0-RC3. This change can break applications that use diode-react if they use older versions of scalajs-react.
+- This version removes the backwards compatibility with Scala 2.12 because of scalajs-react 2.
 
 ## 1.1.8
 - update build/dependencies to support SJS 1.0.0

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ publish / skip := true
 
 val commonSettings = Seq(
   organization := "io.suzaku",
-  crossScalaVersions := Seq("2.12.14", "2.13.6"),
+  crossScalaVersions := Seq("2.13.6"),
   ThisBuild / scalaVersion := "2.13.6",
   scalacOptions := Seq(
     "-deprecation",
@@ -119,7 +119,7 @@ lazy val diodeReact: Project = project
   .settings(
     name := "diode-react",
     libraryDependencies ++= Seq(
-      "com.github.japgolly.scalajs-react" %%% "core" % "1.7.7"
+      "com.github.japgolly.scalajs-react" %%% "core" % "2.0.0-RC3"
     ),
     scalacOptions ++= sourceMapSetting.value
   )


### PR DESCRIPTION
This change allows to use diode-react with applications that use scalajs-react 2, but breaks it for applications using scalajs-react 1.
Following @cquiroz recommendation, I bumped up the version described in the Changelog to 1.2.0-RC1.